### PR TITLE
[#4] Add Api Benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,11 @@ debug = true
 [dev-dependencies]
 proptest = "0.8.3"
 hex = "0.3.2"
+criterion = "0.2"
 
 [features]
 unstable = []
 
+[[bench]]
+name = "api_benchmark"
+harness = false

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ $ cargo build
 $ cargo test
 ```
 
+#### Running benchmarks
+```
+$ cargo bench
+```
+
 # Relation to Proxy Re-Encryption
 
 In the academic literature, _transform encryption_ is referred to as _proxy re-encryption_. A proxy re-encryption (PRE) scheme is a public-key encryption scheme, where each participant has a pair of related keys, one public and one private, which are mathematically related. Alice encrypts a message to Bob using his public key, and Bob decrypts the encrypted message using his public key to retrieve the original message.

--- a/benches/api_benchmark.rs
+++ b/benches/api_benchmark.rs
@@ -291,7 +291,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().sample_size(10);
+    config = Criterion::default().sample_size(20);
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/benches/api_benchmark.rs
+++ b/benches/api_benchmark.rs
@@ -1,0 +1,59 @@
+#[macro_use]
+extern crate criterion;
+extern crate recrypt;
+
+use criterion::Criterion;
+use recrypt::api::Api;
+use recrypt::api::CryptoOps;
+use recrypt::api::Ed25519Ops;
+use recrypt::api::KeyGenOps;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("generate key pair", |b| {
+        let mut api = Api::new();
+        b.iter(|| api.generate_key_pair());
+    });
+    c.bench_function("generate plaintext", |b| {
+        let mut api = Api::new();
+        b.iter(|| api.gen_plaintext());
+    });
+    c.bench_function("generate ed25519 keypair", |b| {
+        let mut api = Api::new();
+        b.iter(|| {
+            api.generate_ed25519_key_pair();
+        });
+    });
+    c.bench_function("encrypt (level 0)", |b| {
+        use std::rc::Rc;
+        use std::cell::RefCell;
+
+        let mut api = Rc::new(RefCell::new(Api::new()));
+        let (_, pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        b.iter_with_setup(
+            || {
+                api.borrow_mut().gen_plaintext()
+            },
+            |pt| {
+                api.borrow_mut().encrypt(pt, pbk, pbsk, pvsk);
+            },
+        );
+    });
+//    c.bench_function("decrypt (level 0)", |b| {
+//        let mut api = Api::new();
+//        let (pvk, pbk) = api.generate_key_pair().unwrap();
+//        let (pvsk, pbsk) = api.generate_ed25519_key_pair();
+//        let pt = api.gen_plaintext();
+//        let encrypted_value = api.encrypt(pt, pbk, pbsk, pvsk).unwrap();
+//        b.iter(|| {
+//            api.decrypt(encrypted_value, pvk);
+//        });
+//    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);
+
+// rename Api to Recrypt
+// gen_plaintext -> generate_plaintext
+// use prelude

--- a/benches/api_benchmark.rs
+++ b/benches/api_benchmark.rs
@@ -51,21 +51,15 @@ fn criterion_benchmark(c: &mut Criterion) {
                 let (pvk, _) = api.borrow_mut().generate_key_pair().unwrap();
                 pvk
             },
-            |pvk| {
-                api.borrow_mut().compute_public_key(&pvk)
-            },
+            |pvk| api.borrow_mut().compute_public_key(&pvk),
         );
     });
 
     c.bench_function("derive symmetric key", |b| {
         let api = RefCell::new(Api::new());
         b.iter_with_setup(
-            || {
-                api.borrow_mut().gen_plaintext()
-            },
-            |pt| {
-                api.borrow_mut().derive_symmetric_key(&pt)
-            },
+            || api.borrow_mut().gen_plaintext(),
+            |pt| api.borrow_mut().derive_symmetric_key(&pt),
         );
     });
 
@@ -87,9 +81,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let (pvsk, pbsk) = api.generate_ed25519_key_pair();
         let pt = api.gen_plaintext();
         let encrypted_value = api.encrypt(&pt, pbk, pbsk, &pvsk).unwrap();
-        b.iter(|| {
-            api.decrypt(encrypted_value.clone(), &pvk).unwrap()
-        });
+        b.iter(|| api.decrypt(encrypted_value.clone(), &pvk).unwrap());
     });
 
     c.bench_function("transform (level 1)", |b| {
@@ -303,5 +295,3 @@ criterion_group! {
     targets = criterion_benchmark
 }
 criterion_main!(benches);
-
-

--- a/benches/api_benchmark.rs
+++ b/benches/api_benchmark.rs
@@ -14,16 +14,19 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut api = Api::new();
         b.iter(|| api.generate_key_pair());
     });
+
     c.bench_function("generate plaintext", |b| {
         let mut api = Api::new();
         b.iter(|| api.gen_plaintext());
     });
+
     c.bench_function("generate ed25519 keypair", |b| {
         let mut api = Api::new();
         b.iter(|| {
             api.generate_ed25519_key_pair();
         });
     });
+
     c.bench_function("generate transform key", |b| {
         let api = RefCell::new(Api::new());
         let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
@@ -40,6 +43,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
         );
     });
+
     c.bench_function("compute public key", |b| {
         let api = RefCell::new(Api::new());
         b.iter_with_setup(
@@ -52,6 +56,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
         );
     });
+
     c.bench_function("derive symmetric key", |b| {
         let api = RefCell::new(Api::new());
         b.iter_with_setup(
@@ -63,6 +68,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
         );
     });
+
     c.bench_function("encrypt (level 0)", |b| {
         let api = RefCell::new(Api::new());
         let (_, pbk) = api.borrow_mut().generate_key_pair().unwrap();
@@ -74,6 +80,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
         );
     });
+
     c.bench_function("decrypt (level 0)", |b| {
         let mut api = Api::new();
         let (pvk, pbk) = api.generate_key_pair().unwrap();
@@ -108,6 +115,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
         );
     });
+
     c.bench_function("decrypt (level 1)", |b| {
         let api = RefCell::new(Api::new());
         let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
@@ -133,6 +141,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
         );
     });
+
     c.bench_function("transform (level 2)", |b| {
         let api = RefCell::new(Api::new());
         let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
@@ -165,36 +174,6 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
         );
     });
-
-    //    c.bench_function("transform (level 2 - simple)", |b| {
-    //        let api = RefCell::new(Api::new());
-    //        let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
-    //        let (level_1_pvk, level_1_pbk) = api.borrow_mut().generate_key_pair().unwrap();
-    //        let (level_2_pvk, level_2_pbk) = api.borrow_mut().generate_key_pair().unwrap();
-    //        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
-    //        let tk_0_to_1 = api
-    //            .borrow_mut()
-    //            .generate_transform_key(&level_0_pvk, level_1_pbk, pbsk, &pvsk)
-    //            .unwrap();
-    //        let tk_1_to_2 = api
-    //            .borrow_mut()
-    //            .generate_transform_key(&level_1_pvk, level_2_pbk, pbsk, &pvsk)
-    //            .unwrap();
-    //        let pt = api.borrow_mut().gen_plaintext();
-    //                let ev = api.borrow_mut()
-    //                    .encrypt(&pt, level_0_pbk, pbsk, &pvsk)
-    //                    .unwrap();
-    //        b.iter(
-    //            || {
-    //                let ev_to_1 = api.borrow_mut()
-    //                    .transform(ev.clone(), tk_0_to_1.clone(), pbsk, &pvsk)
-    //                    .unwrap();
-    //                api.borrow_mut()
-    //                    .transform(ev_to_1, tk_1_to_2.clone(), pbsk, &pvsk)
-    //                    .unwrap();
-    //            },
-    //        );
-    //    });
 
     c.bench_function("decrypt (level 2)", |b| {
         let api = RefCell::new(Api::new());
@@ -272,6 +251,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
         );
     });
+
     c.bench_function("decrypt (level 3)", |b| {
         let api = RefCell::new(Api::new());
         let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();

--- a/benches/api_benchmark.rs
+++ b/benches/api_benchmark.rs
@@ -7,6 +7,7 @@ use recrypt::api::Api;
 use recrypt::api::CryptoOps;
 use recrypt::api::Ed25519Ops;
 use recrypt::api::KeyGenOps;
+use std::cell::RefCell;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("generate key pair", |b| {
@@ -23,37 +24,304 @@ fn criterion_benchmark(c: &mut Criterion) {
             api.generate_ed25519_key_pair();
         });
     });
-    c.bench_function("encrypt (level 0)", |b| {
-        use std::rc::Rc;
-        use std::cell::RefCell;
-
-        let mut api = Rc::new(RefCell::new(Api::new()));
-        let (_, pbk) = api.borrow_mut().generate_key_pair().unwrap();
+    c.bench_function("generate transform key", |b| {
+        let api = RefCell::new(Api::new());
         let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        b.iter_with_setup(
+            || {
+                let (from_pvk, _) = api.borrow_mut().generate_key_pair().unwrap();
+                let (_, to_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+                (from_pvk, to_pbk)
+            },
+            |(from, to)| {
+                api.borrow_mut()
+                    .generate_transform_key(&from, to, pbsk, &pvsk)
+                    .unwrap();
+            },
+        );
+    });
+    c.bench_function("compute public key", |b| {
+        let api = RefCell::new(Api::new());
+        b.iter_with_setup(
+            || {
+                let (pvk, _) = api.borrow_mut().generate_key_pair().unwrap();
+                pvk
+            },
+            |pvk| {
+                api.borrow_mut().compute_public_key(&pvk)
+            },
+        );
+    });
+    c.bench_function("derive symmetric key", |b| {
+        let api = RefCell::new(Api::new());
         b.iter_with_setup(
             || {
                 api.borrow_mut().gen_plaintext()
             },
             |pt| {
-                api.borrow_mut().encrypt(pt, pbk, pbsk, pvsk);
+                api.borrow_mut().derive_symmetric_key(&pt)
             },
         );
     });
-//    c.bench_function("decrypt (level 0)", |b| {
-//        let mut api = Api::new();
-//        let (pvk, pbk) = api.generate_key_pair().unwrap();
-//        let (pvsk, pbsk) = api.generate_ed25519_key_pair();
-//        let pt = api.gen_plaintext();
-//        let encrypted_value = api.encrypt(pt, pbk, pbsk, pvsk).unwrap();
-//        b.iter(|| {
-//            api.decrypt(encrypted_value, pvk);
-//        });
-//    });
+    c.bench_function("encrypt (level 0)", |b| {
+        let api = RefCell::new(Api::new());
+        let (_, pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        b.iter_with_setup(
+            || api.borrow_mut().gen_plaintext(),
+            |pt| {
+                api.borrow_mut().encrypt(&pt, pbk, pbsk, &pvsk).unwrap();
+            },
+        );
+    });
+    c.bench_function("decrypt (level 0)", |b| {
+        let mut api = Api::new();
+        let (pvk, pbk) = api.generate_key_pair().unwrap();
+        let (pvsk, pbsk) = api.generate_ed25519_key_pair();
+        let pt = api.gen_plaintext();
+        let encrypted_value = api.encrypt(&pt, pbk, pbsk, &pvsk).unwrap();
+        b.iter(|| {
+            api.decrypt(encrypted_value.clone(), &pvk).unwrap()
+        });
+    });
+
+    c.bench_function("transform (level 1)", |b| {
+        let api = RefCell::new(Api::new());
+        let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (_, level_1_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        let tk = api
+            .borrow_mut()
+            .generate_transform_key(&level_0_pvk, level_1_pbk, pbsk, &pvsk)
+            .unwrap();
+        b.iter_with_setup(
+            || {
+                let pt = api.borrow_mut().gen_plaintext();
+                api.borrow_mut()
+                    .encrypt(&pt, level_0_pbk, pbsk, &pvsk)
+                    .unwrap()
+            },
+            |ev| {
+                api.borrow_mut()
+                    .transform(ev, tk.clone(), pbsk, &pvsk)
+                    .unwrap()
+            },
+        );
+    });
+    c.bench_function("decrypt (level 1)", |b| {
+        let api = RefCell::new(Api::new());
+        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_1_pvk, level_1_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let tk = api
+            .borrow_mut()
+            .generate_transform_key(&level_0_pvk, level_1_pbk, pbsk, &pvsk)
+            .unwrap();
+        b.iter_with_setup(
+            || {
+                let pt = api.borrow_mut().gen_plaintext();
+                let ev = api
+                    .borrow_mut()
+                    .encrypt(&pt, level_0_pbk, pbsk, &pvsk)
+                    .unwrap();
+                api.borrow_mut()
+                    .transform(ev, tk.clone(), pbsk, &pvsk)
+                    .unwrap()
+            },
+            |ev| {
+                api.borrow_mut().decrypt(ev, &level_1_pvk).unwrap();
+            },
+        );
+    });
+    c.bench_function("transform (level 2)", |b| {
+        let api = RefCell::new(Api::new());
+        let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_1_pvk, level_1_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (_, level_2_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        let tk_0_to_1 = api
+            .borrow_mut()
+            .generate_transform_key(&level_0_pvk, level_1_pbk, pbsk, &pvsk)
+            .unwrap();
+        let tk_1_to_2 = api
+            .borrow_mut()
+            .generate_transform_key(&level_1_pvk, level_2_pbk, pbsk, &pvsk)
+            .unwrap();
+        b.iter_with_setup(
+            || {
+                let pt = api.borrow_mut().gen_plaintext();
+                api.borrow_mut()
+                    .encrypt(&pt, level_0_pbk, pbsk, &pvsk)
+                    .unwrap()
+            },
+            |ev| {
+                let ev_to_1 = api
+                    .borrow_mut()
+                    .transform(ev, tk_0_to_1.clone(), pbsk, &pvsk)
+                    .unwrap();
+                api.borrow_mut()
+                    .transform(ev_to_1, tk_1_to_2.clone(), pbsk, &pvsk)
+                    .unwrap();
+            },
+        );
+    });
+
+    //    c.bench_function("transform (level 2 - simple)", |b| {
+    //        let api = RefCell::new(Api::new());
+    //        let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+    //        let (level_1_pvk, level_1_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+    //        let (level_2_pvk, level_2_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+    //        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+    //        let tk_0_to_1 = api
+    //            .borrow_mut()
+    //            .generate_transform_key(&level_0_pvk, level_1_pbk, pbsk, &pvsk)
+    //            .unwrap();
+    //        let tk_1_to_2 = api
+    //            .borrow_mut()
+    //            .generate_transform_key(&level_1_pvk, level_2_pbk, pbsk, &pvsk)
+    //            .unwrap();
+    //        let pt = api.borrow_mut().gen_plaintext();
+    //                let ev = api.borrow_mut()
+    //                    .encrypt(&pt, level_0_pbk, pbsk, &pvsk)
+    //                    .unwrap();
+    //        b.iter(
+    //            || {
+    //                let ev_to_1 = api.borrow_mut()
+    //                    .transform(ev.clone(), tk_0_to_1.clone(), pbsk, &pvsk)
+    //                    .unwrap();
+    //                api.borrow_mut()
+    //                    .transform(ev_to_1, tk_1_to_2.clone(), pbsk, &pvsk)
+    //                    .unwrap();
+    //            },
+    //        );
+    //    });
+
+    c.bench_function("decrypt (level 2)", |b| {
+        let api = RefCell::new(Api::new());
+        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_1_pvk, level_1_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_2_pvk, level_2_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let tk_0_to_1 = api
+            .borrow_mut()
+            .generate_transform_key(&level_0_pvk, level_1_pbk, pbsk, &pvsk)
+            .unwrap();
+        let tk_1_to_2 = api
+            .borrow_mut()
+            .generate_transform_key(&level_1_pvk, level_2_pbk, pbsk, &pvsk)
+            .unwrap();
+        b.iter_with_setup(
+            || {
+                let pt = api.borrow_mut().gen_plaintext();
+                let ev_to_0 = api
+                    .borrow_mut()
+                    .encrypt(&pt, level_0_pbk, pbsk, &pvsk)
+                    .unwrap();
+                let ev_to_1 = api
+                    .borrow_mut()
+                    .transform(ev_to_0, tk_0_to_1.clone(), pbsk, &pvsk)
+                    .unwrap();
+                api.borrow_mut()
+                    .transform(ev_to_1, tk_1_to_2.clone(), pbsk, &pvsk)
+                    .unwrap()
+            },
+            |ev_to_2| {
+                api.borrow_mut().decrypt(ev_to_2, &level_2_pvk).unwrap();
+            },
+        );
+    });
+
+    c.bench_function("transform (level 3)", |b| {
+        let api = RefCell::new(Api::new());
+        let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_1_pvk, level_1_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_2_pvk, level_2_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (_, level_3_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        let tk_0_to_1 = api
+            .borrow_mut()
+            .generate_transform_key(&level_0_pvk, level_1_pbk, pbsk, &pvsk)
+            .unwrap();
+        let tk_1_to_2 = api
+            .borrow_mut()
+            .generate_transform_key(&level_1_pvk, level_2_pbk, pbsk, &pvsk)
+            .unwrap();
+        let tk_2_to_3 = api
+            .borrow_mut()
+            .generate_transform_key(&level_2_pvk, level_3_pbk, pbsk, &pvsk)
+            .unwrap();
+        b.iter_with_setup(
+            || {
+                let pt = api.borrow_mut().gen_plaintext();
+                api.borrow_mut()
+                    .encrypt(&pt, level_0_pbk, pbsk, &pvsk)
+                    .unwrap()
+            },
+            |ev| {
+                let ev_to_1 = api
+                    .borrow_mut()
+                    .transform(ev, tk_0_to_1.clone(), pbsk, &pvsk)
+                    .unwrap();
+                let ev_to_2 = api
+                    .borrow_mut()
+                    .transform(ev_to_1, tk_1_to_2.clone(), pbsk, &pvsk)
+                    .unwrap();
+                api.borrow_mut()
+                    .transform(ev_to_2, tk_2_to_3.clone(), pbsk, &pvsk)
+                    .unwrap();
+            },
+        );
+    });
+    c.bench_function("decrypt (level 3)", |b| {
+        let api = RefCell::new(Api::new());
+        let (pvsk, pbsk) = api.borrow_mut().generate_ed25519_key_pair();
+        let (level_0_pvk, level_0_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_1_pvk, level_1_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_2_pvk, level_2_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let (level_3_pvk, level_3_pbk) = api.borrow_mut().generate_key_pair().unwrap();
+        let tk_0_to_1 = api
+            .borrow_mut()
+            .generate_transform_key(&level_0_pvk, level_1_pbk, pbsk, &pvsk)
+            .unwrap();
+        let tk_1_to_2 = api
+            .borrow_mut()
+            .generate_transform_key(&level_1_pvk, level_2_pbk, pbsk, &pvsk)
+            .unwrap();
+        let tk_2_to_3 = api
+            .borrow_mut()
+            .generate_transform_key(&level_2_pvk, level_3_pbk, pbsk, &pvsk)
+            .unwrap();
+        b.iter_with_setup(
+            || {
+                let pt = api.borrow_mut().gen_plaintext();
+                let ev_to_0 = api
+                    .borrow_mut()
+                    .encrypt(&pt, level_0_pbk, pbsk, &pvsk)
+                    .unwrap();
+                let ev_to_1 = api
+                    .borrow_mut()
+                    .transform(ev_to_0, tk_0_to_1.clone(), pbsk, &pvsk)
+                    .unwrap();
+                let ev_to_2 = api
+                    .borrow_mut()
+                    .transform(ev_to_1, tk_1_to_2.clone(), pbsk, &pvsk)
+                    .unwrap();
+                api.borrow_mut()
+                    .transform(ev_to_2, tk_2_to_3.clone(), pbsk, &pvsk)
+                    .unwrap()
+            },
+            |ev_to_3| {
+                api.borrow_mut().decrypt(ev_to_3, &level_3_pvk).unwrap();
+            },
+        );
+    });
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = criterion_benchmark
+}
 criterion_main!(benches);
 
-// rename Api to Recrypt
-// gen_plaintext -> generate_plaintext
-// use prelude
+

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,7 @@ use internal;
 use internal::bytedecoder::{BytesDecoder, DecodeErr};
 use internal::curve;
 pub use internal::ed25519::{
-    Ed25519, Ed25519Signing, PrivateSigningKey, PublicSigningKey, Signature,
+    Ed25519, Ed25519Signing, PrivateSigningKey, PublicSigningKey, Ed25519Signature,
 };
 use internal::fp::fr_256::Fr256;
 use internal::fp12elem::Fp12Elem;
@@ -248,7 +248,7 @@ pub enum EncryptedValue {
         encrypted_message: EncryptedMessage,
         auth_hash: AuthHash,
         public_signing_key: PublicSigningKey,
-        signature: Signature,
+        signature: Ed25519Signature,
     },
     /// Value which has been encrypted and then transformed n times for n > 0.
     /// `ephemeral_public_key`  - public key of the ephemeral private key that was used to encrypt
@@ -263,7 +263,7 @@ pub enum EncryptedValue {
         auth_hash: AuthHash,
         transform_blocks: NonEmptyVec<TransformBlock>,
         public_signing_key: PublicSigningKey,
-        signature: Signature,
+        signature: Ed25519Signature,
     },
 }
 
@@ -500,7 +500,7 @@ pub struct TransformKey {
     encrypted_temp_key: EncryptedTempKey,
     hashed_temp_key: HashedValue,
     public_signing_key: PublicSigningKey,
-    signature: Signature,
+    signature: Ed25519Signature,
     _internal_key: internal::SignedValue<internal::ReencryptionKey<Fp256>>,
 }
 
@@ -520,7 +520,7 @@ impl TransformKey {
     pub fn public_signing_key(&self) -> &PublicSigningKey {
         &self.public_signing_key
     }
-    pub fn signature(&self) -> &Signature {
+    pub fn signature(&self) -> &Ed25519Signature {
         &self.signature
     }
     fn try_from_internal(
@@ -545,7 +545,7 @@ impl TransformKey {
         encrypted_temp_key: EncryptedTempKey, //The encrypted K value, which is used to go from the reencrypted value to the encrypted value
         hashed_temp_key: HashedValue,
         public_signing_key: PublicSigningKey,
-        signature: Signature,
+        signature: Ed25519Signature,
     ) -> TransformKey {
         let reencryption_key = internal::ReencryptionKey {
             re_public_key: ephemeral_public_key._internal_key,
@@ -1055,14 +1055,14 @@ pub(crate) mod test {
 
     pub struct DummyEd25519;
     impl Ed25519Signing for DummyEd25519 {
-        fn sign<T: Hashable>(&self, _t: &T, _private_key: &PrivateSigningKey) -> Signature {
-            Signature::new([0; 64])
+        fn sign<T: Hashable>(&self, _t: &T, _private_key: &PrivateSigningKey) -> Ed25519Signature {
+            Ed25519Signature::new([0; 64])
         }
 
         fn verify<T: Hashable>(
             &self,
             _t: &T,
-            _signature: &Signature,
+            _signature: &Ed25519Signature,
             _public_key: &PublicSigningKey,
         ) -> bool {
             true

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,7 @@ use internal;
 use internal::bytedecoder::{BytesDecoder, DecodeErr};
 use internal::curve;
 pub use internal::ed25519::{
-    Ed25519, Ed25519Signing, PrivateSigningKey, PublicSigningKey, Ed25519Signature,
+    Ed25519, Ed25519Signature, Ed25519Signing, PrivateSigningKey, PublicSigningKey,
 };
 use internal::fp::fr_256::Fr256;
 use internal::fp12elem::Fp12Elem;

--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -28,12 +28,12 @@ impl Drop for PrivateSigningKey {
         self.bytes.clear()
     }
 }
-new_bytes_type!(Signature, 64);
+new_bytes_type!(Ed25519Signature, 64);
 
 pub struct Ed25519;
 
 impl Ed25519Signing for Ed25519 {
-    fn sign<T: Hashable>(&self, t: &T, private_key: &PrivateSigningKey) -> Signature {
+    fn sign<T: Hashable>(&self, t: &T, private_key: &PrivateSigningKey) -> Ed25519Signature {
         let private_key_bytes: [u8; 64] = private_key.bytes;
         //This unwrap cannot fail. The only thing that the `from_bytes` does for validation is that the
         //value is 64 bytes long, which we guarentee statically.
@@ -55,14 +55,12 @@ impl Ed25519Signing for Ed25519 {
             &PublicKey::from_bytes(&public_key_point.to_bytes()).unwrap(),
         );
 
-        Signature {
-            bytes: sig.to_bytes(),
-        }
+        Ed25519Signature::new(sig.to_bytes())
     }
     fn verify<T: Hashable>(
         &self,
         t: &T,
-        signature: &Signature,
+        signature: &Ed25519Signature,
         public_key: &PublicSigningKey,
     ) -> bool {
         PublicKey::from_bytes(&public_key.bytes[..])
@@ -78,7 +76,7 @@ pub trait Ed25519Signing {
     ///
     ///Create a signature by signing over the bytes produced by the hashable instance of `t`.
     ///
-    fn sign<T: Hashable>(&self, t: &T, private_key: &PrivateSigningKey) -> Signature;
+    fn sign<T: Hashable>(&self, t: &T, private_key: &PrivateSigningKey) -> Ed25519Signature;
 
     ///
     /// Use the public_key to verify that the signature was signed by its private key over the hashable bytes of
@@ -87,7 +85,7 @@ pub trait Ed25519Signing {
     fn verify<T: Hashable>(
         &self,
         t: &T,
-        signature: &Signature,
+        signature: &Ed25519Signature,
         public_key: &PublicSigningKey,
     ) -> bool;
 }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,7 +1,7 @@
 use clear_on_drop::clear::Clear;
 use gridiron::fp_256::Fp256;
 use internal::curve::CurvePoints;
-use internal::ed25519::{Ed25519Signing, PrivateSigningKey, PublicSigningKey, Ed25519Signature};
+use internal::ed25519::{Ed25519Signature, Ed25519Signing, PrivateSigningKey, PublicSigningKey};
 use internal::field::ExtensionField;
 use internal::field::Field;
 use internal::fp::fr_256::Fr256;

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,7 +1,7 @@
 use clear_on_drop::clear::Clear;
 use gridiron::fp_256::Fp256;
 use internal::curve::CurvePoints;
-use internal::ed25519::{Ed25519Signing, PrivateSigningKey, PublicSigningKey, Signature};
+use internal::ed25519::{Ed25519Signing, PrivateSigningKey, PublicSigningKey, Ed25519Signature};
 use internal::field::ExtensionField;
 use internal::field::Field;
 use internal::fp::fr_256::Fr256;
@@ -129,7 +129,7 @@ where
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct SignedValue<T> {
     pub public_signing_key: PublicSigningKey,
-    pub signature: Signature,
+    pub signature: Ed25519Signature,
     pub payload: T,
 }
 
@@ -1053,14 +1053,14 @@ mod test {
     struct Mocks;
 
     impl Ed25519Signing for Mocks {
-        fn sign<T: Hashable>(&self, _t: &T, _private_key: &PrivateSigningKey) -> Signature {
-            Signature::new([0; 64])
+        fn sign<T: Hashable>(&self, _t: &T, _private_key: &PrivateSigningKey) -> Ed25519Signature {
+            Ed25519Signature::new([0; 64])
         }
 
         fn verify<T: Hashable>(
             &self,
             _t: &T,
-            _signature: &Signature,
+            _signature: &Ed25519Signature,
             _public_key: &PublicSigningKey,
         ) -> bool {
             true
@@ -1076,14 +1076,14 @@ mod test {
     struct AlwaysFailVerifyEd25519Signing;
 
     impl Ed25519Signing for AlwaysFailVerifyEd25519Signing {
-        fn sign<T: Hashable>(&self, _t: &T, _private_key: &PrivateSigningKey) -> Signature {
-            Signature::new([0; 64])
+        fn sign<T: Hashable>(&self, _t: &T, _private_key: &PrivateSigningKey) -> Ed25519Signature {
+            Ed25519Signature::new([0; 64])
         }
 
         fn verify<T: Hashable>(
             &self,
             _t: &T,
-            _signature: &Signature,
+            _signature: &Ed25519Signature,
             _public_key: &PublicSigningKey,
         ) -> bool {
             false


### PR DESCRIPTION
For #4 

Implement the following benchmarks:
* [x] - generate key pair
* [x] - generate ed25519 key pair
* [x] - generate plaintext
* [x] - generate transform key
* [x] - compute public key
* [x] - derive symmetric key
* [x] - encrypt (level 0)
* [x] - transform (level 1)
* [x] - transform (level 2)
* [x] - transform (level 3)
* [x] - decrypt (level 0)
* [x] - decrypt (level 1)
* [x] - decrypt (level 2)
* [x] - decrypt (level 3)

### TODO
* [x] - decide how many samples we want to default to. Currently set to 10.
  - set to 20
* [ ] - commit baseline results
  - decided against for now
* [x] - README instructions for `cargo bench`