### PR TITLE
Remove macro compiler warnings

### DIFF
--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -29,16 +29,22 @@ macro_rules! new_from_slice {
     };
 }
 
-/// macro for generation of "new-types" around byte arrays, but with the option of specifying custom derive
-macro_rules! new_bytes_type_with_derive {
-    ($t: ident, $n: expr, $derive: meta) => {
-
-        #[allow(unused_attributes)] //should squelch error for empty derive, but does not appear to work: https://github.com/rust-lang/rust/issues/54651
+macro_rules! _bytes_struct {
+    ($t: ident) => {
+        pub struct $t {
+            bytes: [u8; $t::ENCODED_SIZE_BYTES],
+        }
+    };
+    ($t: ident, $derive: meta) => {
         #[$derive]
         pub struct $t {
             bytes: [u8; $t::ENCODED_SIZE_BYTES],
         }
+    };
+}
 
+macro_rules! _bytes_core {
+    ($t: ident, $n: expr) => {
         impl $t {
             const ENCODED_SIZE_BYTES: usize = $n;
 
@@ -67,13 +73,19 @@ macro_rules! new_bytes_type_with_derive {
 /// macro for generation of "new-types" around a byte array with a standard pattern for construction and access
 macro_rules! new_bytes_type {
     ($t: ident, $n: expr) => {
-        new_bytes_type_with_derive!($t, $n, derive(Clone, Copy));
+        _bytes_struct!($t, derive(Copy, Clone));
+        _bytes_core!($t, $n);
+    };
+    ($t: ident, $n: expr, $derive: meta) => {
+        _bytes_struct!($t, $n, $derive);
+        _bytes_core!($t, $n);
     };
 }
 
 /// macro for generation of "new-types" around a byte array with a standard pattern for construction and access
 macro_rules! new_bytes_type_no_derive {
     ($t: ident, $n: expr) => {
-        new_bytes_type_with_derive!($t, $n, derive());
+        _bytes_struct!($t);
+        _bytes_core!($t, $n);
     };
 }


### PR DESCRIPTION
The new_bytes_type macros could generate a compiler warning for an empty derive block. The macros have been reworked slightly to eliminate this warning.