### PR TITLE
Change Ed25519 PrivateKey type to SigningKeypair

### DIFF
--- a/benches/api_benchmark.rs
+++ b/benches/api_benchmark.rs
@@ -70,7 +70,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_with_setup(
             || api.borrow_mut().gen_plaintext(),
             |pt| {
-                api.borrow_mut().encrypt(&pt, pbk, &signing_keypair).unwrap();
+                api.borrow_mut()
+                    .encrypt(&pt, pbk, &signing_keypair)
+                    .unwrap();
             },
         );
     });

--- a/src/api.rs
+++ b/src/api.rs
@@ -655,10 +655,7 @@ impl<H, S, CR: rand::RngCore + rand::CryptoRng> Ed25519Ops for Api<H, S, RandomB
     ///Generate a signing key pair for use with the `Ed25519Signing` trait using the random number generator
     ///used to back the `RandomBytes` struct.
     fn generate_ed25519_key_pair(&mut self) -> SigningKeypair {
-        use ed25519_dalek;
-        use sha2::Sha512;
-        let keypair = ed25519_dalek::Keypair::generate::<Sha512, CR>(&mut self.random_bytes.rng);
-        SigningKeypair::new(keypair.to_bytes())
+        SigningKeypair::new(&mut self.random_bytes.rng)
     }
 }
 
@@ -1012,6 +1009,7 @@ impl From<SchnorrSignature> for internal::schnorr::SchnorrSignature<Fr256> {
 pub(crate) mod test {
     use super::*;
     use hex;
+    use internal::ed25519;
     use internal::Square;
     use num_traits::{One, Zero};
     use rand;
@@ -1212,7 +1210,7 @@ pub(crate) mod test {
 
     fn good_transform_key() -> TransformKey {
         let mut api = Api::new();
-        let signing_key = SigningKeypair::new([0; 64]);
+        let signing_key = ed25519::test::good_signing_keypair();
         let (master_priv, master_pub) = api.generate_key_pair().unwrap();
         api.generate_transform_key(&master_priv, master_pub, &signing_key)
             .unwrap()
@@ -1321,7 +1319,7 @@ pub(crate) mod test {
     #[test]
     fn transform_to_same_key() {
         let mut api = api_with(Some(RandomBytes::default()), DummyEd25519);
-        let signing_key = SigningKeypair::new([0; 64]);
+        let signing_key = ed25519::test::good_signing_keypair();
 
         let plaintext = api.gen_plaintext();
         let (master_priv, master_pub) = api.generate_key_pair().unwrap();
@@ -1338,7 +1336,7 @@ pub(crate) mod test {
 
     #[test]
     fn encrypt_decrypt_roundtrip_unaugmented_keys() {
-        let signing_key = SigningKeypair::new([0; 64]);
+        let signing_key = ed25519::test::good_signing_keypair();
         let mut api = api_with(Some(RandomBytes::default()), DummyEd25519);
 
         let pt = api.gen_plaintext();
@@ -1427,7 +1425,7 @@ pub(crate) mod test {
         use rand::SeedableRng;
         let mut api = Api::new_with_rand(rand::ChaChaRng::from_seed([0u8; 32]));
         let signing_keypair = api.generate_ed25519_key_pair();
-        let expected_signing_keypair = SigningKeypair::new([
+        let expected_signing_keypair = SigningKeypair::new_unchecked([
             118, 184, 224, 173, 160, 241, 61, 144, 64, 93, 106, 229, 83, 134, 189, 40, 189, 210,
             25, 184, 160, 141, 237, 26, 168, 54, 239, 204, 139, 119, 13, 199, 32, 253, 186, 201,
             177, 11, 117, 135, 187, 167, 181, 188, 22, 59, 206, 105, 231, 150, 215, 30, 78, 212,

--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -1,7 +1,8 @@
 use api::ApiErr;
 use clear_on_drop::clear::Clear;
 use ed25519_dalek;
-use ed25519_dalek::{ExpandedSecretKey, PublicKey};
+use ed25519_dalek::PublicKey;
+use internal::array_split_64;
 use internal::hashable::Hashable;
 use internal::ByteVector;
 use sha2::Sha512;
@@ -29,14 +30,15 @@ impl Hashable for PublicSigningKey {
     }
 }
 
-// we don't derive Copy or Clone here on purpose. PrivateSigningKey is a sensitive value and
+// we don't derive Copy or Clone here on purpose. SigningKeypair is a sensitive value and
 // should be passed by reference to avoid needless duplication
-new_bytes_type_no_derive!(PrivateSigningKey, 64);
+/// The first 32 bytes of this are the Secret Ed25519 key and the 2nd 32 bytes are the Compressed Y form
+/// of the public key.
+new_bytes_type_no_derive!(SigningKeypair, 64);
 
-impl PrivateSigningKey {
-    pub fn compute_public_key(&self) -> PublicSigningKey {
-        let pub_key: PublicKey = ExpandedSecretKey::from_bytes(&self.bytes).unwrap().into();
-        PublicSigningKey::new(pub_key.to_bytes())
+impl SigningKeypair {
+    pub fn public_key(&self) -> PublicSigningKey {
+        PublicSigningKey::from(self)
     }
 
     ///
@@ -47,7 +49,14 @@ impl PrivateSigningKey {
     }
 }
 
-impl Drop for PrivateSigningKey {
+impl<'a> From<&'a SigningKeypair> for PublicSigningKey {
+    fn from(kp: &SigningKeypair) -> PublicSigningKey {
+        let (_, pub_bytes) = array_split_64(&kp.bytes);
+        PublicSigningKey::new(pub_bytes)
+    }
+}
+
+impl Drop for SigningKeypair {
     fn drop(&mut self) {
         self.bytes.clear()
     }
@@ -57,10 +66,10 @@ new_bytes_type!(Ed25519Signature, 64);
 pub struct Ed25519;
 
 impl Ed25519Signing for Ed25519 {
-    fn sign<T: Hashable>(&self, t: &T, private_key: &PrivateSigningKey) -> Ed25519Signature {
+    fn sign<T: Hashable>(&self, t: &T, signing_key: &SigningKeypair) -> Ed25519Signature {
         //This unwrap cannot fail. The only thing that the `from_bytes` does for validation is that the
         //value is 64 bytes long, which we guarentee statically.
-        let key_pair = ed25519_dalek::Keypair::from_bytes(&private_key.bytes[..]).unwrap();
+        let key_pair = ed25519_dalek::Keypair::from_bytes(&signing_key.bytes[..]).unwrap();
         let sig = key_pair.sign::<Sha512>(&t.to_bytes()[..]);
 
         Ed25519Signature::new(sig.to_bytes())
@@ -84,7 +93,7 @@ pub trait Ed25519Signing {
     ///
     ///Create a signature by signing over the bytes produced by the hashable instance of `t`.
     ///
-    fn sign<T: Hashable>(&self, t: &T, private_key: &PrivateSigningKey) -> Ed25519Signature;
+    fn sign<T: Hashable>(&self, t: &T, signing_key: &SigningKeypair) -> Ed25519Signature;
 
     ///
     /// Use the public_key to verify that the signature was signed by its private key over the hashable bytes of
@@ -106,23 +115,16 @@ mod test {
     #[test]
     fn real_ed25519_matches_verify_good_message() {
         let sec_key = SecretKey::from_bytes(&[1; 32]).unwrap();
-        let priv_key = PrivateSigningKey {
-            bytes: array_concat_32(
-                &sec_key.to_bytes(),
-                &ed25519_dalek::PublicKey::from_secret::<Sha512>(&sec_key).to_bytes(),
-            ),
+        let dalek_pub_key = ed25519_dalek::PublicKey::from_secret::<Sha512>(&sec_key);
+        let priv_key = SigningKeypair {
+            bytes: array_concat_32(&sec_key.to_bytes(), &dalek_pub_key.to_bytes()),
         };
         let message = [100u8; 32].to_vec();
         let result = Ed25519.sign(&message, &priv_key);
         let verify_result = Ed25519.verify(
             &message,
             &result,
-            &PublicSigningKey {
-                bytes: [
-                    138, 136, 227, 221, 116, 9, 241, 149, 253, 82, 219, 45, 60, 186, 93, 114, 202,
-                    103, 9, 191, 29, 148, 18, 27, 243, 116, 136, 1, 180, 15, 111, 92,
-                ],
-            },
+            &PublicSigningKey::new(dalek_pub_key.to_bytes()),
         );
         assert!(verify_result);
     }

--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -5,6 +5,7 @@ use ed25519_dalek::PublicKey;
 use internal::array_split_64;
 use internal::hashable::Hashable;
 use internal::ByteVector;
+use rand;
 use sha2::Sha512;
 use std;
 use std::fmt;
@@ -30,13 +31,78 @@ impl Hashable for PublicSigningKey {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum Ed25519Error {
+    PublicKeyInvalid([u8; 32]),
+    InputWrongSize { expected: usize, actual: usize },
+}
+
 // we don't derive Copy or Clone here on purpose. SigningKeypair is a sensitive value and
 // should be passed by reference to avoid needless duplication
 /// The first 32 bytes of this are the Secret Ed25519 key and the 2nd 32 bytes are the Compressed Y form
 /// of the public key.
-new_bytes_type_no_derive!(SigningKeypair, 64);
+pub struct SigningKeypair {
+    pub(crate) bytes: [u8; 64],
+}
+bytes_only_debug!(SigningKeypair);
+impl PartialEq for SigningKeypair {
+    fn eq(&self, other: &SigningKeypair) -> bool {
+        self.bytes[..] == other.bytes[..]
+    }
+}
+
+impl Eq for SigningKeypair {}
 
 impl SigningKeypair {
+    const ENCODED_SIZE_BYTES: usize = 64;
+    pub fn new<CR: rand::RngCore + rand::CryptoRng>(rng: &mut CR) -> SigningKeypair {
+        use sha2::Sha512;
+        let keypair = ed25519_dalek::Keypair::generate::<Sha512, CR>(rng);
+        //Unchecked is safe because the public is on the curve and the size is statically guaranteed.
+        SigningKeypair::new_unchecked(keypair.to_bytes())
+    }
+    ///
+    ///Create a SigningKeypair from a byte array slice. If the array is not the right length or if the public
+    ///key doesn't match the private, it will return an Ed25519Error.
+    ///
+    pub fn from_byte_slice(bytes: &[u8]) -> Result<SigningKeypair, Ed25519Error> {
+        let bytes_size = bytes.len();
+        let sized_bytes = if bytes_size == SigningKeypair::ENCODED_SIZE_BYTES {
+            let mut dest = [0u8; SigningKeypair::ENCODED_SIZE_BYTES];
+            dest.copy_from_slice(bytes);
+            Ok(dest)
+        } else {
+            Err(Ed25519Error::InputWrongSize {
+                expected: SigningKeypair::ENCODED_SIZE_BYTES,
+                actual: bytes_size,
+            })
+        }?;
+        SigningKeypair::from_bytes(&sized_bytes)
+    }
+
+    ///
+    ///Create a SigningKeypair from a sized array of bytes. This can fail if the public key portion doesn't
+    ///match the private key.
+    ///
+    pub fn from_bytes(sized_bytes: &[u8; 64]) -> Result<SigningKeypair, Ed25519Error> {
+        let (priv_key, pub_key) = array_split_64(sized_bytes);
+        //This can't fail because it's statically guaranteed to be 32 bytes long.
+        let ed25519_dalek_secret = ed25519_dalek::SecretKey::from_bytes(&priv_key).unwrap();
+        //Calculate the public key to check that the value passed in is correct.
+        let ed25519_dalek_pub =
+            ed25519_dalek::PublicKey::from_secret::<Sha512>(&ed25519_dalek_secret);
+        if ed25519_dalek_pub.to_bytes() == pub_key {
+            Ok(SigningKeypair::new_unchecked(*sized_bytes))
+        } else {
+            Err(Ed25519Error::PublicKeyInvalid(pub_key))
+        }
+    }
+
+    pub(crate) fn new_unchecked(bytes: [u8; 64]) -> SigningKeypair {
+        SigningKeypair { bytes }
+    }
+
+    ///Get the public_key portion of this SigningKeypair.
     pub fn public_key(&self) -> PublicSigningKey {
         PublicSigningKey::from(self)
     }
@@ -52,6 +118,7 @@ impl SigningKeypair {
 impl<'a> From<&'a SigningKeypair> for PublicSigningKey {
     fn from(kp: &SigningKeypair) -> PublicSigningKey {
         let (_, pub_bytes) = array_split_64(&kp.bytes);
+
         PublicSigningKey::new(pub_bytes)
     }
 }
@@ -68,7 +135,7 @@ pub struct Ed25519;
 impl Ed25519Signing for Ed25519 {
     fn sign<T: Hashable>(&self, t: &T, signing_key: &SigningKeypair) -> Ed25519Signature {
         //This unwrap cannot fail. The only thing that the `from_bytes` does for validation is that the
-        //value is 64 bytes long, which we guarentee statically.
+        //value is 64 bytes long, which we guarantee statically.
         let key_pair = ed25519_dalek::Keypair::from_bytes(&signing_key.bytes[..]).unwrap();
         let sig = key_pair.sign::<Sha512>(&t.to_bytes()[..]);
 
@@ -108,10 +175,19 @@ pub trait Ed25519Signing {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
     use ed25519_dalek::SecretKey;
     use internal::array_concat_32;
+
+    pub fn good_signing_keypair() -> SigningKeypair {
+        SigningKeypair::new_unchecked([
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 138, 136, 227, 221, 116, 9, 241, 149, 253, 82, 219, 45, 60, 186, 93, 114, 202,
+            103, 9, 191, 29, 148, 18, 27, 243, 116, 136, 1, 180, 15, 111, 92,
+        ])
+    }
+
     #[test]
     fn real_ed25519_matches_verify_good_message() {
         let sec_key = SecretKey::from_bytes(&[1; 32]).unwrap();
@@ -127,5 +203,23 @@ mod test {
             &PublicSigningKey::new(dalek_pub_key.to_bytes()),
         );
         assert!(verify_result);
+    }
+
+    #[test]
+    fn signing_keypair_from_bytes() {
+        let bytes = [0u8; 63];
+        let error = SigningKeypair::from_byte_slice(&bytes)
+            .expect_err("Keypair should be too short so this can't happen.");
+        assert_eq!(
+            error,
+            Ed25519Error::InputWrongSize {
+                expected: 64,
+                actual: 63
+            }
+        );
+
+        let error2 = SigningKeypair::from_byte_slice(&[0u8; 64])
+            .expect_err("Public key error should happen.");
+        assert_eq!(error2, Ed25519Error::PublicKeyInvalid([0u8; 32]))
     }
 }

--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -108,7 +108,7 @@ impl SigningKeypair {
     }
 
     ///Export the bytes of the keypair.
-    pub fn bytes(&self) -> [u8;64] {
+    pub fn bytes(&self) -> [u8; 64] {
         self.bytes
     }
 

--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -107,6 +107,11 @@ impl SigningKeypair {
         PublicSigningKey::from(self)
     }
 
+    ///Export the bytes of the keypair.
+    pub fn bytes(&self) -> [u8;64] {
+        self.bytes
+    }
+
     ///
     ///Create a signature by signing over the bytes produced by the hashable instance of `message`.
     ///

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -81,11 +81,3 @@ macro_rules! new_bytes_type {
         _bytes_core!($t, $n);
     };
 }
-
-/// macro for generation of "new-types" around a byte array with a standard pattern for construction and access
-macro_rules! new_bytes_type_no_derive {
-    ($t: ident, $n: expr) => {
-        _bytes_struct!($t);
-        _bytes_core!($t, $n);
-    };
-}

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1789,10 +1789,9 @@ mod test {
             191, 29, 148, 18, 27, 243, 116, 136, 1, 180, 15, 111, 92,
         ]);
         let priv_signing_key = ed25519::PrivateSigningKey::new([
-            88, 232, 110, 251, 117, 250, 78, 44, 65, 15, 70, 225, 109, 233, 246, 172, 174, 26, 23,
-            3, 82, 134, 81, 182, 155, 193, 118, 192, 136, 190, 243, 110, 177, 122, 42, 44, 243,
-            212, 164, 26, 142, 78, 24, 204, 69, 200, 101, 109, 85, 142, 206, 221, 176, 173, 180,
-            107, 250, 8, 138, 95, 83, 190, 210, 82,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 138, 136, 227, 221, 116, 9, 241, 149, 253, 82, 219, 45, 60, 186, 93, 114, 202,
+            103, 9, 191, 29, 148, 18, 27, 243, 116, 136, 1, 180, 15, 111, 92,
         ]);
         (priv_signing_key, pub_signing_key)
     }
@@ -1803,7 +1802,7 @@ mod test {
             let (priv_signing_key, pub_signing_key) = good_signing_keys();
             let signed_value = sign_value(fp256, pub_signing_key, &priv_signing_key, &Ed25519);
             let verified = verify_signed_value(signed_value, &Ed25519);
-            assert!(verified.is_some())
+            prop_assert!(verified.is_some())
         }
         #[test]
         fn encrypt_decrypt_roundtrip(priv_key in arb_priv_key(), plaintext in arb_fp12().prop_filter("", |a| !(*a == Fp12Elem::<Fp256>::zero()))) {

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,7 +1,7 @@
 use clear_on_drop::clear::Clear;
 use gridiron::fp_256::Fp256;
 use internal::curve::CurvePoints;
-use internal::ed25519::{Ed25519Signature, Ed25519Signing, PrivateSigningKey, PublicSigningKey};
+use internal::ed25519::{Ed25519Signature, Ed25519Signing, PublicSigningKey, SigningKeypair};
 use internal::field::ExtensionField;
 use internal::field::Field;
 use internal::fp::fr_256::Fr256;
@@ -367,22 +367,21 @@ where
 ///
 /// # Arguments
 /// `payload` - value to sign; must be a type with an associated Hashable instance
-/// `public_signing_key` - the Ed25519 public key to embed in the output; can be used to validate signature
-/// `private_signing_key` - the Ed25519 private key that is used to compute the signature
+/// `signing_keypair` - the Ed25519 keypair that is used to compute the signature
 /// `ed25519` - Implementation of `Ed25519Signing` trait
 ///
 /// # Return
 /// SignedValue<T> - contains the value `payload`, the public signingkey, and the computed signature
 fn sign_value<T, F: Ed25519Signing>(
     payload: T,
-    public_signing_key: PublicSigningKey,
-    private_signing_key: &PrivateSigningKey,
+    signing_keypair: &SigningKeypair,
     ed25519: &F,
 ) -> SignedValue<T>
 where
     T: Hashable + Clone,
 {
-    let signature = ed25519.sign(&(public_signing_key, payload.clone()), private_signing_key);
+    let public_signing_key = signing_keypair.public_key();
+    let signature = ed25519.sign(&(public_signing_key, payload.clone()), signing_keypair);
     SignedValue {
         public_signing_key,
         signature,
@@ -405,8 +404,7 @@ where
 /// `to_public_key`         - the public key to encrypt to
 /// `plaintext`             - the value to encrypt - must be an element of G_T
 /// `encrypting_key`        - a random private key value chosen just for this plaintext
-/// `public_signing_key`    - the public portion of the encrypter's signing key pair
-/// `private_signing_key`   - the private portion of the encrypter's signing key pair
+/// `signing_keypair`       - the public portion of the encrypter's signing key pair
 /// `pairing`               - Optimal Ate Pairing
 /// `curve_points`          - IronCore's curve
 /// `hash`                  - Sha256Hashing instance
@@ -419,8 +417,7 @@ pub fn encrypt<T: Clone, F: Sha256Hashing, G: Ed25519Signing>(
     to_public_key: PublicKey<T>,
     plaintext: Fp12Elem<T>, // @clintfred can this be any fp12? or an rth root?
     encrypting_key: PrivateKey<T>,
-    public_signing_key: PublicSigningKey,
-    private_signing_key: &PrivateSigningKey,
+    signing_keypair: &SigningKeypair,
     pairing: &Pairing<T>,
     curve_points: &CurvePoints<T>,
     hash: &F,
@@ -441,8 +438,7 @@ where
             encrypted_message,
             auth_hash,
         }),
-        public_signing_key,
-        private_signing_key,
+        signing_keypair,
         sign,
     )
 }
@@ -666,8 +662,7 @@ fn verify_signed_value<T: Hashable + Clone, G: Ed25519Signing>(
 /// `to_public_key`             - the public key to transform to
 /// `reencryption_private_key`  - a random private key
 /// `new_k`                     - a random FP12 element
-/// `public_signing_key`        - Ed25519 public key to include to validate signature
-/// `private_signing_key`       - Ed25519 private key to use to sign reencryption key
+/// `signing_keypair`           - Ed25519 keypair to use to sign reencryption key
 /// `curve_points`              - IronCore's curve
 /// `sha256`                    - Sha256 instance
 /// `ed25519`                   - Ed25519Signing instance
@@ -681,8 +676,7 @@ pub fn generate_reencryption_key<FP, H, S>(
     to_public_key: PublicKey<FP>,
     reencryption_private_key: PrivateKey<FP>,
     new_k: KValue<FP>,
-    public_signing_key: PublicSigningKey,
-    private_signing_key: &PrivateSigningKey,
+    signing_keypair: &SigningKeypair,
     curve_points: &CurvePoints<FP>,
     pairing: &Pairing<FP>,
     sha256: &H,
@@ -712,12 +706,7 @@ where
         hashed_k,
     };
 
-    sign_value(
-        reencryption_key,
-        public_signing_key,
-        private_signing_key,
-        ed25519,
-    )
+    sign_value(reencryption_key, signing_keypair, ed25519)
 }
 
 /// Fp12Elem that is private and is used in the transform/decrypt algorithms
@@ -840,8 +829,7 @@ pub fn reencrypt<FP, S, H>(
     signed_encrypted_value: SignedValue<EncryptedValue<FP>>,
     rand_re_priv_key: PrivateKey<FP>,
     rand_re_k: KValue<FP>,
-    public_signing_key: PublicSigningKey,
-    private_signing_key: &PrivateSigningKey,
+    signing_keypair: &SigningKeypair,
     ed25519: &S,
     sha256: &H,
     curve_points: &CurvePoints<FP>,
@@ -872,8 +860,7 @@ where
                 pairing,
                 sha256,
             )),
-            public_signing_key,
-            private_signing_key,
+            signing_keypair,
             ed25519,
         )),
 
@@ -887,8 +874,7 @@ where
                 pairing,
                 sha256,
             )),
-            public_signing_key,
-            private_signing_key,
+            signing_keypair,
             ed25519,
         )),
         (None, _) => Err(InternalError::SignatureFailed),
@@ -1053,7 +1039,7 @@ mod test {
     struct Mocks;
 
     impl Ed25519Signing for Mocks {
-        fn sign<T: Hashable>(&self, _t: &T, _private_key: &PrivateSigningKey) -> Ed25519Signature {
+        fn sign<T: Hashable>(&self, _t: &T, _signing_keypair: &SigningKeypair) -> Ed25519Signature {
             Ed25519Signature::new([0; 64])
         }
 
@@ -1076,7 +1062,7 @@ mod test {
     struct AlwaysFailVerifyEd25519Signing;
 
     impl Ed25519Signing for AlwaysFailVerifyEd25519Signing {
-        fn sign<T: Hashable>(&self, _t: &T, _private_key: &PrivateSigningKey) -> Ed25519Signature {
+        fn sign<T: Hashable>(&self, _t: &T,  _signing_keypair: &SigningKeypair) -> Ed25519Signature {
             Ed25519Signature::new([0; 64])
         }
 
@@ -1138,8 +1124,7 @@ mod test {
         let ref curve_points = *curve::FP_256_CURVE_POINTS;
         let ref sha256 = sha256::Sha256;
         let ref ed25519 = api::test::DummyEd25519;
-        let pbsk = PublicSigningKey::new([0;32]);
-        let pvsk = PrivateSigningKey::new([0;64]);
+        let signing_keypair = SigningKeypair::new([0;64]);
 
         //37777967648492203239675772600961898148040325589588086812374811831221462604944
         let parsed_priv_key = Fp256::new(
@@ -1213,8 +1198,7 @@ mod test {
             public_key,
             re_private_key,
             salt,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             curve_points,
             &pairing,
             sha256,
@@ -1323,8 +1307,7 @@ mod test {
         let ref sha256 = sha256::Sha256;
         let ref ed25519 = api::test::DummyEd25519;
         let salt = KValue(gen_rth_root(&pairing, salt_fp12));
-        let pbsk = PublicSigningKey::new([0; 32]);
-        let pvsk = PrivateSigningKey::new([0; 64]);
+        let signing_keypair = SigningKeypair::new([0; 64]);
 
         let re_private = PrivateKey::from_fp256(
             //22002131259228303741090495322318969764532178674829148099822698556219881568451
@@ -1359,8 +1342,7 @@ mod test {
             pub_key,
             plaintext,
             ephem_priv_key,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             &pairing,
             curve_points,
             sha256,
@@ -1381,8 +1363,7 @@ mod test {
             pub_key,
             re_private,
             salt,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             curve_points,
             &pairing,
             sha256,
@@ -1394,8 +1375,7 @@ mod test {
             encrypt_result,
             rand_re_priv_key,
             rand_re_k,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             ed25519,
             sha256,
             curve_points,
@@ -1419,8 +1399,7 @@ mod test {
         let ref curve_points = *curve::FP_256_CURVE_POINTS;
         let ref sha256 = sha256::Sha256;
         let salt1 = gen_rth_root(&pairing, gen_random_fp12(&mut DummyRandomBytes));
-        let pbsk = PublicSigningKey::new([0; 32]);
-        let pvsk = PrivateSigningKey::new([0; 64]);
+        let signing_keypair = SigningKeypair::new([0; 64]);
         let priv_key = PrivateKey::from_fp256(
             //43966559432365357341903140497410248873099149633601160471165130153973144042658
             Fp256::new([
@@ -1444,8 +1423,7 @@ mod test {
             pub_key,
             salt1,
             ephem_priv_key,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             &pairing,
             curve_points,
             sha256,
@@ -1472,8 +1450,7 @@ mod test {
         let ref curve_points = *curve::FP_256_CURVE_POINTS;
         let ref sha256 = sha256::Sha256;
         let salt1 = gen_rth_root(&pairing, gen_random_fp12(&mut DummyRandomBytes));
-        let pbsk = PublicSigningKey::new([0; 32]);
-        let pvsk = PrivateSigningKey::new([0; 64]);
+        let signing_keypair = SigningKeypair::new([0; 64]);
         let priv_key = PrivateKey::from_fp256(
             //43966559432365357341903140497410248873099149633601160471165130153973144042658
             Fp256::new([
@@ -1497,8 +1474,7 @@ mod test {
             pub_key,
             salt1,
             ephem_priv_key,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             &pairing,
             curve_points,
             sha256,
@@ -1599,8 +1575,7 @@ mod test {
         let ref sha256 = sha256::Sha256;
         let ref ed25519 = api::test::DummyEd25519;
         let salt1 = KValue(gen_rth_root(&pairing, salt_1_fp12));
-        let pbsk = PublicSigningKey::new([0; 32]);
-        let pvsk = PrivateSigningKey::new([0; 64]);
+        let signing_keypair = SigningKeypair::new([0; 64]);
 
         let re_private = PrivateKey::from_fp256(
             //22002131259228303741090495322318969764532178674829148099822698556219881568451
@@ -1658,8 +1633,7 @@ mod test {
             pub_key,
             plaintext,
             ephem_priv_key,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             &pairing,
             curve_points,
             sha256,
@@ -1680,8 +1654,7 @@ mod test {
             pub_key2,
             re_private,
             salt1,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             curve_points,
             &pairing,
             sha256,
@@ -1694,8 +1667,7 @@ mod test {
             encrypt_result,
             rand_re_priv_key,
             rand_re_k,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             ed25519,
             sha256,
             curve_points,
@@ -1728,8 +1700,7 @@ mod test {
             pub_key3,
             re_priv_2,
             salt2,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             curve_points,
             &pairing,
             sha256,
@@ -1741,8 +1712,7 @@ mod test {
             reencrypted_value,
             rand_re_priv_key_2,
             rand_re_k_2,
-            pbsk,
-            &pvsk,
+            &signing_keypair,
             ed25519,
             sha256,
             curve_points,
@@ -1782,25 +1752,24 @@ mod test {
         }
     }
 
-    fn good_signing_keys() -> (PrivateSigningKey, PublicSigningKey) {
+    fn good_signing_keys() -> SigningKeypair {
         // pub/priv signing keys precomputed
-        let pub_signing_key = ed25519::PublicSigningKey::new([
+        let pub_signing_key = [
             138, 136, 227, 221, 116, 9, 241, 149, 253, 82, 219, 45, 60, 186, 93, 114, 202, 103, 9,
             191, 29, 148, 18, 27, 243, 116, 136, 1, 180, 15, 111, 92,
-        ]);
-        let priv_signing_key = ed25519::PrivateSigningKey::new([
+        ];
+        let priv_signing_key =[
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 138, 136, 227, 221, 116, 9, 241, 149, 253, 82, 219, 45, 60, 186, 93, 114, 202,
-            103, 9, 191, 29, 148, 18, 27, 243, 116, 136, 1, 180, 15, 111, 92,
-        ]);
-        (priv_signing_key, pub_signing_key)
+            1, 1, 1
+        ];
+        SigningKeypair::new(array_concat_32(&priv_signing_key, &pub_signing_key))
     }
 
     proptest! {
         #[test]
         fn sign_verify_roundtrip(fp256 in arb_fp256()) {
-            let (priv_signing_key, pub_signing_key) = good_signing_keys();
-            let signed_value = sign_value(fp256, pub_signing_key, &priv_signing_key, &Ed25519);
+            let priv_signing_key = good_signing_keys();
+            let signed_value = sign_value(fp256, &priv_signing_key, &Ed25519);
             let verified = verify_signed_value(signed_value, &Ed25519);
             prop_assert!(verified.is_some())
         }
@@ -1808,14 +1777,13 @@ mod test {
         fn encrypt_decrypt_roundtrip(priv_key in arb_priv_key(), plaintext in arb_fp12().prop_filter("", |a| !(*a == Fp12Elem::<Fp256>::zero()))) {
             let pub_key = public_keygen(priv_key, curve::FP_256_CURVE_POINTS.generator);
             let ephem_secret_key = PrivateKey::from_fp256(Fp256::new_from_u64(42));
-            let (priv_signing_key, pub_signing_key) = good_signing_keys();
+            let priv_signing_key = good_signing_keys();
             let pairing = pairing::Pairing::new();
             let curve_points = &*curve::FP_256_CURVE_POINTS;
             let encrypt_result = encrypt(
                 pub_key,
                 plaintext,
                 ephem_secret_key,
-                pub_signing_key,
                 &priv_signing_key,
                 &pairing,
                 curve_points,
@@ -1894,8 +1862,7 @@ mod test {
                 to_public_key,
                 *reencryption_private_key,
                 KValue(*new_k),
-                PublicSigningKey::new([0; 32]),
-                &PrivateSigningKey::new([0;64]),
+                &SigningKeypair::new([0;64]),
                 &curve_points,
                 &pairing,
                 &Mocks,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1062,7 +1062,7 @@ mod test {
     struct AlwaysFailVerifyEd25519Signing;
 
     impl Ed25519Signing for AlwaysFailVerifyEd25519Signing {
-        fn sign<T: Hashable>(&self, _t: &T,  _signing_keypair: &SigningKeypair) -> Ed25519Signature {
+        fn sign<T: Hashable>(&self, _t: &T, _signing_keypair: &SigningKeypair) -> Ed25519Signature {
             Ed25519Signature::new([0; 64])
         }
 
@@ -1758,9 +1758,9 @@ mod test {
             138, 136, 227, 221, 116, 9, 241, 149, 253, 82, 219, 45, 60, 186, 93, 114, 202, 103, 9,
             191, 29, 148, 18, 27, 243, 116, 136, 1, 180, 15, 111, 92,
         ];
-        let priv_signing_key =[
+        let priv_signing_key = [
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1
+            1, 1, 1,
         ];
         SigningKeypair::new(array_concat_32(&priv_signing_key, &pub_signing_key))
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1124,7 +1124,7 @@ mod test {
         let ref curve_points = *curve::FP_256_CURVE_POINTS;
         let ref sha256 = sha256::Sha256;
         let ref ed25519 = api::test::DummyEd25519;
-        let signing_keypair = SigningKeypair::new([0;64]);
+        let signing_keypair = ed25519::test::good_signing_keypair();
 
         //37777967648492203239675772600961898148040325589588086812374811831221462604944
         let parsed_priv_key = Fp256::new(
@@ -1307,7 +1307,7 @@ mod test {
         let ref sha256 = sha256::Sha256;
         let ref ed25519 = api::test::DummyEd25519;
         let salt = KValue(gen_rth_root(&pairing, salt_fp12));
-        let signing_keypair = SigningKeypair::new([0; 64]);
+        let signing_keypair = ed25519::test::good_signing_keypair();
 
         let re_private = PrivateKey::from_fp256(
             //22002131259228303741090495322318969764532178674829148099822698556219881568451
@@ -1399,7 +1399,7 @@ mod test {
         let ref curve_points = *curve::FP_256_CURVE_POINTS;
         let ref sha256 = sha256::Sha256;
         let salt1 = gen_rth_root(&pairing, gen_random_fp12(&mut DummyRandomBytes));
-        let signing_keypair = SigningKeypair::new([0; 64]);
+        let signing_keypair = ed25519::test::good_signing_keypair();
         let priv_key = PrivateKey::from_fp256(
             //43966559432365357341903140497410248873099149633601160471165130153973144042658
             Fp256::new([
@@ -1450,7 +1450,7 @@ mod test {
         let ref curve_points = *curve::FP_256_CURVE_POINTS;
         let ref sha256 = sha256::Sha256;
         let salt1 = gen_rth_root(&pairing, gen_random_fp12(&mut DummyRandomBytes));
-        let signing_keypair = SigningKeypair::new([0; 64]);
+        let signing_keypair = ed25519::test::good_signing_keypair();
         let priv_key = PrivateKey::from_fp256(
             //43966559432365357341903140497410248873099149633601160471165130153973144042658
             Fp256::new([
@@ -1575,7 +1575,7 @@ mod test {
         let ref sha256 = sha256::Sha256;
         let ref ed25519 = api::test::DummyEd25519;
         let salt1 = KValue(gen_rth_root(&pairing, salt_1_fp12));
-        let signing_keypair = SigningKeypair::new([0; 64]);
+        let signing_keypair = ed25519::test::good_signing_keypair();
 
         let re_private = PrivateKey::from_fp256(
             //22002131259228303741090495322318969764532178674829148099822698556219881568451
@@ -1753,16 +1753,7 @@ mod test {
     }
 
     fn good_signing_keys() -> SigningKeypair {
-        // pub/priv signing keys precomputed
-        let pub_signing_key = [
-            138, 136, 227, 221, 116, 9, 241, 149, 253, 82, 219, 45, 60, 186, 93, 114, 202, 103, 9,
-            191, 29, 148, 18, 27, 243, 116, 136, 1, 180, 15, 111, 92,
-        ];
-        let priv_signing_key = [
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1,
-        ];
-        SigningKeypair::new(array_concat_32(&priv_signing_key, &pub_signing_key))
+        ed25519::test::good_signing_keypair()
     }
 
     proptest! {
@@ -1862,7 +1853,7 @@ mod test {
                 to_public_key,
                 *reencryption_private_key,
                 KValue(*new_k),
-                &SigningKeypair::new([0;64]),
+                &ed25519::test::good_signing_keypair(),
                 &curve_points,
                 &pairing,
                 &Mocks,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@
 //!
 //! // generate a public/private keypair and some signing keys
 //! let (priv_key, pub_key) = api.generate_key_pair().unwrap();
-//! let (priv_signing_key, pub_signing_key) = api.generate_ed25519_key_pair();
+//! let signing_keypair = api.generate_ed25519_key_pair();
 //!
 //! // encrypt!
-//! let encrypted_val = api.encrypt(&pt, pub_key, pub_signing_key, &priv_signing_key).unwrap();
+//! let encrypted_val = api.encrypt(&pt, pub_key, &signing_keypair).unwrap();
 //!
 //! // decrypt!
 //! let decrypted_val = api.decrypt(encrypted_val, &priv_key).unwrap();
@@ -40,13 +40,13 @@
 //! let pt = api.gen_plaintext();
 //!
 //! // generate signing keys
-//! let (priv_signing_key, pub_signing_key) = api.generate_ed25519_key_pair();
+//! let signing_keypair= api.generate_ed25519_key_pair();
 //!
 //! // generate a public/private keypair to encrypt the data to initially.
 //! let (initial_priv_key, initial_pub_key) = api.generate_key_pair().unwrap();
 //!
 //! // encrypt the data to `initial_pub_key`!
-//! let encrypted_val = api.encrypt(&pt, initial_pub_key, pub_signing_key, &priv_signing_key).unwrap();
+//! let encrypted_val = api.encrypt(&pt, initial_pub_key, &signing_keypair).unwrap();
 //!
 //! // generate a second public/private keypair as the target of the transform.
 //! // after applying the transform, `target_priv_key` will be able to decrypt the data!
@@ -56,16 +56,14 @@
 //! let initial_to_target_transform_key = api.generate_transform_key(
 //!     &initial_priv_key,
 //!     target_pub_key,
-//!     pub_signing_key,
-//!     &priv_signing_key).unwrap();
+//!     &signing_keypair).unwrap();
 //!
 //! // Transform the plaintext to be encrypted to the target!
 //! // The data is _not_ be decrypted here. Simply transformed!
 //! let transformed_val = api.transform(
 //!     encrypted_val,
 //!     initial_to_target_transform_key,
-//!     pub_signing_key,
-//!     &priv_signing_key).unwrap();
+//!     &signing_keypair).unwrap();
 //!
 //! // decrypt the transformed value with the target private key and recover the plaintext
 //! let decrypted_val = api.decrypt(transformed_val, &target_priv_key).unwrap();


### PR DESCRIPTION
Previously we were interpreting the PrivateSigningKey as an ExpandedSecretKey for ed25519. It turns out that in the other recrypt the ed25519 private key (which is 64 bytes) is actually the 32 byte seed followed by the 32 byte compressed Y form of the public key. 

I've done the following in this PR:

- Change the name PrivateSigningKey to SigningKeypair to best reflect the actual value.
- Change the sign function to interpret the value correctly.
- Added a test using a known key from the other library
- Made all public apis take only the 64 byte keypair instead of 2 params for public and private.