### PR TITLE
Add lto for release builds to show more realistic perf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ debug = true
 opt-level = 2 # Build deps with optimization, don't build ourselves with optimization
 debug = true
 
+[profile.release]
+opt-level = 3 # Build deps with optimization, don't build ourselves with optimization
+debug = false
+lto = true
+
 [dev-dependencies]
 proptest = "0.8.3"
 hex = "0.3.2"


### PR DESCRIPTION
Old:
```
encrypt (level 0)        21.315 ms
decrypt (level 0)        19.574 ms
transform (level 1)     53.610 ms
decrypt (level 1)         66.192 ms
transform (level 2)     125.08 ms
decrypt (level 2)         112.15 ms
```
New:
```
encrypt (level 0)        21.007 ms
decrypt (level 0)        18.795 ms
transform (level 1)     52.862 ms
decrypt (level 1)        64.940 ms
transform (level 2)     125.00 ms
decrypt (level 2)        109.37 ms
```

These are run on my thinkpad x1 with `cargo bench` and leaves out some things, but is meant just to show that it gets better. I think this gives slightly more accurate results.