### PR TITLE
Implmement a display for ed25519 and NonEmptyVec errors so we can propagate those err…

### DIFF
--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -37,6 +37,15 @@ pub enum Ed25519Error {
     InputWrongSize { expected: usize, actual: usize },
 }
 
+impl fmt::Display for Ed25519Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+       match *self {
+           Ed25519Error::PublicKeyInvalid(_) => write!(f, "The signing public key provided was invalid."),
+           Ed25519Error::InputWrongSize { expected: ex, actual: ac } => write!(f, "The key pair provided was of an invalid length. Expected '{}' but found '{}'.", ex, ac),
+       }
+    }
+}
+
 // we don't derive Copy or Clone here on purpose. SigningKeypair is a sensitive value and
 // should be passed by reference to avoid needless duplication
 /// The first 32 bytes of this are the Secret Ed25519 key and the 2nd 32 bytes are the Compressed Y form

--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -39,10 +39,19 @@ pub enum Ed25519Error {
 
 impl fmt::Display for Ed25519Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-       match *self {
-           Ed25519Error::PublicKeyInvalid(_) => write!(f, "The signing public key provided was invalid."),
-           Ed25519Error::InputWrongSize { expected: ex, actual: ac } => write!(f, "The key pair provided was of an invalid length. Expected '{}' but found '{}'.", ex, ac),
-       }
+        match *self {
+            Ed25519Error::PublicKeyInvalid(_) => {
+                write!(f, "The signing public key provided was invalid.")
+            }
+            Ed25519Error::InputWrongSize {
+                expected: ex,
+                actual: ac,
+            } => write!(
+                f,
+                "The key pair provided was of an invalid length. Expected '{}' but found '{}'.",
+                ex, ac
+            ),
+        }
     }
 }
 

--- a/src/nonemptyvec.rs
+++ b/src/nonemptyvec.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 /// A simple-minded NonEmptyVec implementation
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct NonEmptyVec<T> {
@@ -7,6 +9,12 @@ pub struct NonEmptyVec<T> {
 
 #[derive(Debug)]
 pub struct EmptyVectorErr;
+
+impl fmt::Display for EmptyVectorErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NonEmptyVec should not be empty.")
+    }
+}
 
 impl<T> NonEmptyVec<T>
 where

--- a/src/nonemptyvec.rs
+++ b/src/nonemptyvec.rs
@@ -1,18 +1,15 @@
-use std::fmt;
-
 /// A simple-minded NonEmptyVec implementation
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct NonEmptyVec<T> {
     first: T,
     rest: Vec<T>,
 }
-
-#[derive(Debug)]
-pub struct EmptyVectorErr;
-
-impl fmt::Display for EmptyVectorErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "NonEmptyVec should not be empty.")
+quick_error! {
+    #[derive(Debug)]
+    pub enum NonEmptyVecError {
+        EmptyVectorErr {
+            display("NonEmptyVec cannot be empty.")
+        }
     }
 }
 
@@ -46,9 +43,9 @@ where
         self.clone().into()
     }
 
-    pub fn try_from(v: &[T]) -> Result<NonEmptyVec<T>, EmptyVectorErr> {
+    pub fn try_from(v: &[T]) -> Result<NonEmptyVec<T>, NonEmptyVecError> {
         if v.is_empty() {
-            Err(EmptyVectorErr)
+            Err(NonEmptyVecError::EmptyVectorErr)
         } else {
             let first = v[0].clone();
             let rest = v[1..].to_vec();


### PR DESCRIPTION
…ors up to the bindings. 

I don't know if there are additional tests to add as part of this or not, but I'm sure I'll find out in code review :).