### PR TITLE
Mul and pow for u32 instead of u64 and call out that they're not constant time.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ arrayvec = "~0.4"
 ed25519-dalek = { git = "https://github.com/IronCoreLabs/ed25519-dalek", branch = "rand-0.6"}
 curve25519-dalek = "1.0.0-pre.1"
 clear_on_drop = "~0.2"
-gridiron = "0.4.1"
+gridiron = { git = "https://github.com/IronCoreLabs/gridiron", branch = "removeu64"}
 quick-error = "~1.2"
 hex="~0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ arrayvec = "~0.4"
 ed25519-dalek = { git = "https://github.com/IronCoreLabs/ed25519-dalek", branch = "rand-0.6"}
 curve25519-dalek = "1.0.0-pre.1"
 clear_on_drop = "~0.2"
-gridiron = { git = "https://github.com/IronCoreLabs/gridiron", branch = "removeu64"}
+gridiron = "0.5.0" 
 quick-error = "~1.2"
 hex="~0.3"
 

--- a/src/internal/field.rs
+++ b/src/internal/field.rs
@@ -19,9 +19,9 @@ pub trait Field:
     + Add<Output = Self>
     + Mul<Output = Self>
     + Div<Output = Self>
-    + Mul<u64, Output = Self>
+    + Mul<u32, Output = Self>
     + Inv<Output = Self>
-    + Pow<u64, Output = Self>
+    + Pow<u32, Output = Self>
     + Sub<Output = Self>
 {
     fn prop_semigroup(a: Self, b: Self, c: Self) -> bool {

--- a/src/internal/fp12elem.rs
+++ b/src/internal/fp12elem.rs
@@ -96,7 +96,7 @@ where
         }
     }
 }
-
+///Scale the fp12 by a u32. Note that this reveals the u32, but not the Fp12 itself.
 impl<T> Mul<u32> for Fp12Elem<T>
 where
     T: Copy + Add<Output = T> + Zero + PartialEq,
@@ -211,6 +211,7 @@ where
     }
 }
 
+///Note that this reveals the u32, but not the Fp12 itself.
 impl<T> Pow<u32> for Fp12Elem<T>
 where
     T: ExtensionField,

--- a/src/internal/fp12elem.rs
+++ b/src/internal/fp12elem.rs
@@ -97,13 +97,13 @@ where
     }
 }
 
-impl<T> Mul<u64> for Fp12Elem<T>
+impl<T> Mul<u32> for Fp12Elem<T>
 where
     T: Copy + Add<Output = T> + Zero + PartialEq,
 {
     type Output = Fp12Elem<T>;
 
-    fn mul(self, other: u64) -> Self {
+    fn mul(self, other: u32) -> Self {
         sum_n(self, other)
     }
 }
@@ -114,7 +114,7 @@ where
         + Sub<Output = T>
         + Add<Output = T>
         + Copy
-        + Mul<u64, Output = T>
+        + Mul<u32, Output = T>
         + ExtensionField,
 {
     type Output = Fp12Elem<T>;
@@ -174,7 +174,7 @@ where
         + Sub<Output = T>
         + Add<Output = T>
         + PartialEq
-        + Mul<u64, Output = T>
+        + Mul<u32, Output = T>
         + ExtensionField
         + Copy,
 {
@@ -211,19 +211,19 @@ where
     }
 }
 
-impl<T> Pow<u64> for Fp12Elem<T>
+impl<T> Pow<u32> for Fp12Elem<T>
 where
     T: ExtensionField,
 {
     type Output = Fp12Elem<T>;
-    fn pow(self, rhs: u64) -> Self {
+    fn pow(self, rhs: u32) -> Self {
         pow_for_square(self, rhs)
     }
 }
 
 impl<T> Square for Fp12Elem<T>
 where
-    T: Clone + Field + Mul<u64, Output = T> + ExtensionField,
+    T: Clone + Field + Mul<u32, Output = T> + ExtensionField,
 {
     fn square(&self) -> Self {
         let a2 = self.elem1 * self.elem2 * 2;
@@ -235,7 +235,7 @@ where
     }
 }
 
-impl<T> Field for Fp12Elem<T> where T: ExtensionField + Mul<u64, Output = T> {}
+impl<T> Field for Fp12Elem<T> where T: ExtensionField {}
 
 impl<T> Fp12Elem<T>
 where
@@ -433,8 +433,8 @@ pub mod test {
         fn fp256_pow_test(ref fp1 in arb_fp12(), x in any::<u32>(), y in any::<u32>()) {
             //fp1^(x + y) == fp1^x * fp1^y
 
-            let x = x as u64; //cast to avoid overflows
-            let y = y as u64;
+            let x = x >> 1; //shift to avoid overflows
+            let y = y >> 1;
             let left = fp1.pow(x + y);
             let right = fp1.pow(x) * fp1.pow(y);
 

--- a/src/internal/fp12elem.rs
+++ b/src/internal/fp12elem.rs
@@ -434,7 +434,7 @@ pub mod test {
         fn fp256_pow_test(ref fp1 in arb_fp12(), x in any::<u32>(), y in any::<u32>()) {
             //fp1^(x + y) == fp1^x * fp1^y
 
-            let x = x >> 1; //shift to avoid overflows
+            let x = x & 0x7FFFFFFF; //mask to avoid overflows
             let y = y >> 1;
             let left = fp1.pow(x + y);
             let right = fp1.pow(x) * fp1.pow(y);

--- a/src/internal/fp12elem.rs
+++ b/src/internal/fp12elem.rs
@@ -96,7 +96,7 @@ where
         }
     }
 }
-///Scale the fp12 by a u32. Note that this reveals the u32, but not the Fp12 itself.
+///This is not constant time. It reveals the u32, but not the Fp12 itself.
 impl<T> Mul<u32> for Fp12Elem<T>
 where
     T: Copy + Add<Output = T> + Zero + PartialEq,
@@ -211,7 +211,7 @@ where
     }
 }
 
-///Note that this reveals the u32, but not the Fp12 itself.
+///This is not constant time. It reveals the u32, but not the Fp12 itself.
 impl<T> Pow<u32> for Fp12Elem<T>
 where
     T: ExtensionField,

--- a/src/internal/fp2elem.rs
+++ b/src/internal/fp2elem.rs
@@ -86,13 +86,13 @@ where
     }
 }
 
-impl<T> Mul<u64> for Fp2Elem<T>
+impl<T> Mul<u32> for Fp2Elem<T>
 where
-    T: Mul<u64, Output = T>,
+    T: Mul<u32, Output = T>,
 {
     type Output = Fp2Elem<T>;
 
-    fn mul(self, other: u64) -> Self {
+    fn mul(self, other: u32) -> Self {
         Fp2Elem {
             elem1: self.elem1 * other,
             elem2: self.elem2 * other,
@@ -106,7 +106,7 @@ where
         + Inv<Output = T>
         + Sub<Output = T>
         + Add<Output = T>
-        + Pow<u64, Output = T>
+        + Pow<u32, Output = T>
         + Add<Output = T>
         + Neg<Output = T>
         + Div<Output = T>
@@ -168,7 +168,7 @@ where
 
 impl<T> Inv for Fp2Elem<T>
 where
-    T: Pow<u64, Output = T> + Add<Output = T> + Neg<Output = T> + Div<Output = T> + Copy,
+    T: Pow<u32, Output = T> + Add<Output = T> + Neg<Output = T> + Div<Output = T> + Copy,
 {
     type Output = Fp2Elem<T>;
     fn inv(self) -> Fp2Elem<T> {
@@ -180,12 +180,12 @@ where
     }
 }
 
-impl<T> Pow<u64> for Fp2Elem<T>
+impl<T> Pow<u32> for Fp2Elem<T>
 where
     T: Field,
 {
     type Output = Fp2Elem<T>;
-    fn pow(self, rhs: u64) -> Self {
+    fn pow(self, rhs: u32) -> Self {
         pow_for_square(self, rhs)
     }
 }

--- a/src/internal/fp2elem.rs
+++ b/src/internal/fp2elem.rs
@@ -86,6 +86,7 @@ where
     }
 }
 
+///Scale the point by a u32. Note that this reveals the u32, but not the point itself.
 impl<T> Mul<u32> for Fp2Elem<T>
 where
     T: Mul<u32, Output = T>,
@@ -102,15 +103,7 @@ where
 
 impl<T> Div<Fp2Elem<T>> for Fp2Elem<T>
 where
-    T: Mul<Output = T>
-        + Inv<Output = T>
-        + Sub<Output = T>
-        + Add<Output = T>
-        + Pow<u32, Output = T>
-        + Add<Output = T>
-        + Neg<Output = T>
-        + Div<Output = T>
-        + Copy,
+    T: Field
 {
     type Output = Fp2Elem<T>;
     fn div(self, other: Fp2Elem<T>) -> Self {
@@ -180,6 +173,7 @@ where
     }
 }
 
+///Note that this reveals the u32, but not the point itself.
 impl<T> Pow<u32> for Fp2Elem<T>
 where
     T: Field,

--- a/src/internal/fp2elem.rs
+++ b/src/internal/fp2elem.rs
@@ -103,7 +103,7 @@ where
 
 impl<T> Div<Fp2Elem<T>> for Fp2Elem<T>
 where
-    T: Field
+    T: Field,
 {
     type Output = Fp2Elem<T>;
     fn div(self, other: Fp2Elem<T>) -> Self {

--- a/src/internal/fp2elem.rs
+++ b/src/internal/fp2elem.rs
@@ -86,7 +86,7 @@ where
     }
 }
 
-///Scale the point by a u32. Note that this reveals the u32, but not the point itself.
+///This is not constant time. It reveals the u32, but not the point itself.
 impl<T> Mul<u32> for Fp2Elem<T>
 where
     T: Mul<u32, Output = T>,
@@ -173,7 +173,7 @@ where
     }
 }
 
-///Note that this reveals the u32, but not the point itself.
+///This is not constant time. It reveals the u32, but not the point itself.
 impl<T> Pow<u32> for Fp2Elem<T>
 where
     T: Field,

--- a/src/internal/fp6elem.rs
+++ b/src/internal/fp6elem.rs
@@ -98,6 +98,7 @@ where
     }
 }
 
+///Note that this reveals the u32, but not the Fp6 itself.
 impl<T> Mul<u32> for Fp6Elem<T>
 where
     T: Copy + Add<Output = T> + Zero + PartialEq,
@@ -237,6 +238,7 @@ where
     }
 }
 
+///Note that this reveals the u32, but not the Fp6 itself.
 impl<T> Pow<u32> for Fp6Elem<T>
 where
     T: ExtensionField,

--- a/src/internal/fp6elem.rs
+++ b/src/internal/fp6elem.rs
@@ -98,7 +98,7 @@ where
     }
 }
 
-///Note that this reveals the u32, but not the Fp6 itself.
+///This is not constant time. It reveals the u32, but not the Fp6 itself.
 impl<T> Mul<u32> for Fp6Elem<T>
 where
     T: Copy + Add<Output = T> + Zero + PartialEq,
@@ -238,7 +238,7 @@ where
     }
 }
 
-///Note that this reveals the u32, but not the Fp6 itself.
+///This is not constant time. It reveals the u32, but not the fp6 itself.
 impl<T> Pow<u32> for Fp6Elem<T>
 where
     T: ExtensionField,

--- a/src/internal/fp6elem.rs
+++ b/src/internal/fp6elem.rs
@@ -98,13 +98,13 @@ where
     }
 }
 
-impl<T> Mul<u64> for Fp6Elem<T>
+impl<T> Mul<u32> for Fp6Elem<T>
 where
     T: Copy + Add<Output = T> + Zero + PartialEq,
 {
     type Output = Fp6Elem<T>;
 
-    fn mul(self, other: u64) -> Self {
+    fn mul(self, other: u32) -> Self {
         sum_n(self, other)
     }
 }
@@ -237,12 +237,12 @@ where
     }
 }
 
-impl<T> Pow<u64> for Fp6Elem<T>
+impl<T> Pow<u32> for Fp6Elem<T>
 where
     T: ExtensionField,
 {
     type Output = Fp6Elem<T>;
-    fn pow(self, rhs: u64) -> Self {
+    fn pow(self, rhs: u32) -> Self {
         pow_for_square(self, rhs)
     }
 }
@@ -468,8 +468,8 @@ pub mod test {
         fn pow_test_1(ref fp1 in arb_fp6(), x in any::<u32>(), y in any::<u32>()) {
             //fp1^(x + y) == fp1^x * fp1^y
 
-            let x = x as u64; //cast to avoid overflows
-            let y = y as u64;
+            let x = x >> 1; //shift to avoid overflows
+            let y = y >> 1;
             let left = fp1.pow(x + y);
             let right = fp1.pow(x) * fp1.pow(y);
 

--- a/src/internal/fp6elem.rs
+++ b/src/internal/fp6elem.rs
@@ -470,7 +470,7 @@ pub mod test {
         fn pow_test_1(ref fp1 in arb_fp6(), x in any::<u32>(), y in any::<u32>()) {
             //fp1^(x + y) == fp1^x * fp1^y
 
-            let x = x >> 1; //shift to avoid overflows
+            let x = x & 0x7FFFFFFF; //mask to avoid overflows
             let y = y >> 1;
             let left = fp1.pow(x + y);
             let right = fp1.pow(x) * fp1.pow(y);

--- a/src/internal/homogeneouspoint.rs
+++ b/src/internal/homogeneouspoint.rs
@@ -204,7 +204,7 @@ pub trait Double {
 
 impl<T: Field> Double for HomogeneousPoint<T> {
     fn double(&self) -> HomogeneousPoint<T> {
-        let (x, y, z) = double(self.x, self.y, self.z, 9u64);
+        let (x, y, z) = double(self.x, self.y, self.z, 9);
         HomogeneousPoint { x, y, z }
     }
 }
@@ -479,10 +479,10 @@ where
     let y_squared = y.pow(2);
     let z_squared = z.pow(2);
     let three_b_times_z_squared = z_squared * three_b;
-    let eight_times_y_squared = y_squared * 8u64; // 8Y^2
-    let m1 = y_squared - (three_b_times_z_squared * 3u64); // Y^2 - 9bZ^2
+    let eight_times_y_squared = y_squared * 8; // 8Y^2
+    let m1 = y_squared - (three_b_times_z_squared * 3); // Y^2 - 9bZ^2
     let m2 = y_squared + three_b_times_z_squared; // Y^2 + 3bZ^2
-    let x3 = x * y * m1 * 2u64;
+    let x3 = x * y * m1 * 2;
     let y3 = m1 * m2 + three_b_times_z_squared * eight_times_y_squared;
     let z3 = eight_times_y_squared * y * z;
     (x3, y3, z3)
@@ -624,8 +624,8 @@ pub mod test {
 
             #[test]
             fn add_equals_mult(a in $arb_homogeneous()) {
-                prop_assert!(a + a == a * $fp::from(2u64));
-                prop_assert!(a + a + a == a * $fp::from(3u64));
+                prop_assert!(a + a == a * $fp::from(2u32));
+                prop_assert!(a + a + a == a * $fp::from(3u32));
             }
 
             #[test]
@@ -668,9 +668,9 @@ pub mod test {
             #[test]
             fn twisted_add_equals_mult(a in $arb_homogeneous_fp2()) {
                 let added = a + a;
-                prop_assert_eq!(added.normalize(),  (a * $fp::from(2u64)).normalize());
-                prop_assert!(a + a == a * $fp::from(2u64));
-                prop_assert!(a + a + a == a * $fp::from(3u64));
+                prop_assert_eq!(added.normalize(),  (a * $fp::from(2u32)).normalize());
+                prop_assert!(a + a == a * $fp::from(2u32));
+                prop_assert!(a + a + a == a * $fp::from(3u32));
             }
 
             #[test]

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -336,7 +336,8 @@ impl Square for Fr480 {
     }
 }
 
-///Sum t n times. Reveals the n, but if the t has a constant time add, doesn't re
+///Sum t n times.
+///This is not constant time, it reveals the n, but if the t has a constant time add, doesn't reveal the t.
 fn sum_n<T: Add<Output = T> + Copy + Zero + PartialEq>(t: T, n: u32) -> T {
     if n == 0 {
         Zero::zero()
@@ -354,7 +355,7 @@ fn sum_n_loop<T: Add<Output = T> + Copy>(t: T, k: u32, extra: T) -> T {
     }
 }
 
-///Note that this reveals the u32, but not t as long as it has constant time multiply and square.
+/// This is not constant time, it reveals the n, but if the t has a constant time square and multiply, doesn't reveal the t.
 fn pow_for_square<T: One + Mul<T, Output = T> + Copy + Square>(t: T, exp: u32) -> T {
     if exp == 0 {
         T::one()

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -336,7 +336,7 @@ impl Square for Fr480 {
     }
 }
 
-///Sum t n times.
+///Sum t n times. Reveals the n, but if the t has a constant time add, doesn't re
 fn sum_n<T: Add<Output = T> + Copy + Zero + PartialEq>(t: T, n: u32) -> T {
     if n == 0 {
         Zero::zero()
@@ -354,6 +354,7 @@ fn sum_n_loop<T: Add<Output = T> + Copy>(t: T, k: u32, extra: T) -> T {
     }
 }
 
+///Note that this reveals the u32, but not t as long as it has constant time multiply and square.
 fn pow_for_square<T: One + Mul<T, Output = T> + Copy + Square>(t: T, exp: u32) -> T {
     if exp == 0 {
         T::one()

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -337,7 +337,7 @@ impl Square for Fr480 {
 }
 
 ///Sum t n times.
-fn sum_n<T: Add<Output = T> + Copy + Zero + PartialEq>(t: T, n: u64) -> T {
+fn sum_n<T: Add<Output = T> + Copy + Zero + PartialEq>(t: T, n: u32) -> T {
     if n == 0 {
         Zero::zero()
     } else {
@@ -345,7 +345,7 @@ fn sum_n<T: Add<Output = T> + Copy + Zero + PartialEq>(t: T, n: u64) -> T {
     }
 }
 
-fn sum_n_loop<T: Add<Output = T> + Copy>(t: T, k: u64, extra: T) -> T {
+fn sum_n_loop<T: Add<Output = T> + Copy>(t: T, k: u32, extra: T) -> T {
     if k == 1 {
         t + extra
     } else {
@@ -354,7 +354,7 @@ fn sum_n_loop<T: Add<Output = T> + Copy>(t: T, k: u64, extra: T) -> T {
     }
 }
 
-fn pow_for_square<T: One + Mul<T, Output = T> + Copy + Square>(t: T, exp: u64) -> T {
+fn pow_for_square<T: One + Mul<T, Output = T> + Copy + Square>(t: T, exp: u32) -> T {
     if exp == 0 {
         T::one()
     } else {
@@ -1085,24 +1085,24 @@ mod test {
     use proptest::arbitrary::any;
     use proptest::prelude::*;
     prop_compose! {
-        [pub] fn arb_fp256()(seed in any::<u64>()) -> Fp256 {
+        [pub] fn arb_fp256()(seed in any::<u32>()) -> Fp256 {
             if seed == 0 {
                 Fp256::zero()
             } else if seed == 1 {
                 Fp256::one()
             } else {
-                Fp256::from(seed).pow(seed)
+                Fp256::from(seed).pow(seed).pow(seed)
             }
         }
     }
     prop_compose! {
-        [pub] fn arb_fp480()(seed in any::<u64>()) -> Fp480 {
+        [pub] fn arb_fp480()(seed in any::<u32>()) -> Fp480 {
             if seed == 0 {
                 Fp480::zero()
             } else if seed == 1 {
                 Fp480::one()
             } else {
-                Fp480::from(seed).pow(seed)
+                Fp480::from(seed).pow(seed).pow(seed)
             }
 
         }
@@ -1780,9 +1780,9 @@ mod test {
         fn sum_n_is_times(x in any::<i32>(), n in any::<i32>()) {
             //all the casts are to ensure we don't overflow.
             let computed_result = if n < 0 {
-                -sum_n(x as i64, n.abs() as u64)
+                -sum_n(x as i64, n.abs() as u32)
             } else{
-                sum_n(x as i64, n as u64)
+                sum_n(x as i64, n as u32)
             };
             prop_assert_eq!(computed_result, (x as i64) * (n as i64));
         }

--- a/src/internal/pairing.rs
+++ b/src/internal/pairing.rs
@@ -679,16 +679,14 @@ mod test {
       //"follow the law pair(a * P, a * Q) == pair(P, Q) ^ (a^2)"
       #[test]
       fn law_bilinearity(a in any::<u32>().prop_filter("", |a| !(*a == 0))) {
-        let a: u64 = a as u64;
         let pairing: Pairing<Fp256> = Pairing::new();
         let p = FP_256_CURVE_POINTS.generator;
-        let a_sqr = Fp256::from(a.pow(2));
-        let a_sqr_u64: u64 = a.pow(2) as u64;
-        let a = Fp256::from(a);
-        let a_times_p = p * a;
+        let a_sqr = Fp256::from(a).pow(2);
+        let a_fp256 = Fp256::from(a);
+        let a_times_p = p * a_fp256;
         let a_sqr_times_p = p * a_sqr;
         let q = FP_256_CURVE_POINTS.g1;
-        let a_times_q = q * a;
+        let a_times_q = q * a_fp256;
         let pair_a_times_p_and_a_times_q  = pairing.pair(a_times_p, a_times_q);
 
         // pair(a * P, a * Q) == pair(a^2 * P, Q) == pair(P,a^2 * Q)"
@@ -696,23 +694,22 @@ mod test {
         prop_assert_eq!(pair_a_times_p_and_a_times_q, pairing.pair(a_sqr_times_p, q));
 
         // pair(a * P, a * Q) == pair(P, Q) ^ (a^2)
-        prop_assert_eq!(pair_a_times_p_and_a_times_q, pairing.pair(p, q).pow(a_sqr_u64));
+        prop_assert_eq!(pair_a_times_p_and_a_times_q, pairing.pair(p, q).pow(a).pow(a));
       }
 
       //"follow the law pair(a * P, a * Q) == pair(a^2 * P, Q) == pair(P,a^2 * Q)"
       //"follow the law pair(a * P, a * Q) == pair(P, Q) ^ (a^2)"
       #[test]
       fn fp480_law_bilinearity(a in any::<u32>().prop_filter("", |a| !(*a == 0))) {
-        let a: u64 = a as u64;
+        let a_u64 = a as u64;
         let pairing: Pairing<Fp480> = Pairing::new();
         let p = FP_480_CURVE_POINTS.generator;
-        let a_sqr = Fp480::from(a.pow(2));
-        let a_sqr_u64: u64 = a.pow(2) as u64;
-        let a = Fp480::from(a);
-        let a_times_p = p * a;
+        let a_sqr = Fp480::from(a_u64.pow(2));
+        let a_fp480 = Fp480::from(a);
+        let a_times_p = p * a_fp480;
         let a_sqr_times_p = p * a_sqr;
         let q = FP_480_CURVE_POINTS.g1;
-        let a_times_q = q * a;
+        let a_times_q = q * a_fp480;
         let pair_a_times_p_and_a_times_q  = pairing.pair(a_times_p, a_times_q);
 
         // pair(a * P, a * Q) == pair(a^2 * P, Q) == pair(P,a^2 * Q)"
@@ -720,7 +717,7 @@ mod test {
         prop_assert_eq!(pair_a_times_p_and_a_times_q, pairing.pair(a_sqr_times_p, q));
 
         // pair(a * P, a * Q) == pair(P, Q) ^ (a^2)
-        prop_assert_eq!(pair_a_times_p_and_a_times_q, pairing.pair(p, q).pow(a_sqr_u64));
+        prop_assert_eq!(pair_a_times_p_and_a_times_q, pairing.pair(p, q).pow(a).pow(a));
       }
     }
 }

--- a/src/internal/schnorr.rs
+++ b/src/internal/schnorr.rs
@@ -166,13 +166,13 @@ mod test {
     use proptest::prelude::*;
 
     prop_compose! {
-        [pub] fn arb_fr256()(seed in any::<u64>()) -> Fr256 {
+        [pub] fn arb_fr256()(seed in any::<u32>()) -> Fr256 {
             if seed == 0 {
                 Fr256::zero()
             } else if seed == 1 {
                 Fr256::one()
             } else {
-                Fr256::from(seed).pow(seed)
+                Fr256::from(seed).pow(seed).pow(seed)
             }
         }
     }


### PR DESCRIPTION
Mul by small scalars doesn't need to be constant time in the scalar, it should instead be commented to make that fact clear. Also standardize on u32.

- [x] Bump gridiron version and depend on published version