### PR TITLE
Add comments to is_one and is_zero

### DIFF
--- a/src/internal/fp12elem.rs
+++ b/src/internal/fp12elem.rs
@@ -162,6 +162,7 @@ where
         }
     }
 
+    //This is not constant time and shouldn't be used for algorithms that are.
     fn is_zero(&self) -> bool {
         *self == Zero::zero()
     }
@@ -185,6 +186,7 @@ where
         }
     }
 
+    //This is not constant time and shouldn't be used for algorithms that are.
     fn is_one(&self) -> bool {
         *self == One::one()
     }

--- a/src/internal/fp2elem.rs
+++ b/src/internal/fp2elem.rs
@@ -138,6 +138,7 @@ where
         }
     }
 
+    //This is not constant time and shouldn't be used for algorithms that are.
     fn is_zero(&self) -> bool {
         *self == Fp2Elem::zero()
     }
@@ -154,6 +155,7 @@ where
         }
     }
 
+    //This is not constant time and shouldn't be used for algorithms that are.
     fn is_one(&self) -> bool {
         *self == One::one()
     }

--- a/src/internal/fp6elem.rs
+++ b/src/internal/fp6elem.rs
@@ -172,6 +172,7 @@ where
         }
     }
 
+    //This is not constant time and shouldn't be used for algorithms that are.
     fn is_zero(&self) -> bool {
         *self == Zero::zero()
     }
@@ -189,6 +190,7 @@ where
         }
     }
 
+    //This is not constant time and shouldn't be used for algorithms that are.
     fn is_one(&self) -> bool {
         *self == One::one()
     }

--- a/src/internal/homogeneouspoint.rs
+++ b/src/internal/homogeneouspoint.rs
@@ -56,8 +56,6 @@ where
 {
     fn eq(&self, other: &HomogeneousPoint<T>) -> bool {
         match (*self, *other) {
-            (ref p1, ref p2) if p1.is_zero() && p2.is_zero() => true,
-            (ref p1, ref p2) if p1.is_zero() || p2.is_zero() => false,
             (
                 HomogeneousPoint {
                     x: x1,
@@ -137,6 +135,7 @@ where
         }
     }
 
+    //This is not constant time and shouldn't be used for algorithms that are.
     fn is_zero(&self) -> bool {
         self.z == Zero::zero()
     }
@@ -250,8 +249,6 @@ where
 {
     fn eq(&self, other: &TwistedHPoint<T>) -> bool {
         match (*self, *other) {
-            (ref p1, ref p2) if p1.is_zero() && p2.is_zero() => true,
-            (ref p1, ref p2) if p1.is_zero() || p2.is_zero() => false,
             (
                 TwistedHPoint {
                     x: x1,
@@ -332,6 +329,7 @@ where
         }
     }
 
+    //This is not constant time and shouldn't be used for algorithms that are.
     fn is_zero(&self) -> bool {
         self.z == Zero::zero()
     }


### PR DESCRIPTION
I also removed short circuiting is_zero checks in the equality just to get rid of uses that weren't needed. 