### PR TITLE
[#63] Add prelude for easier importing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,9 @@
 //!
 //! ## Basic Encrypt/Decrypt Example
 //! ```
+//! use recrypt::prelude::*;
 //! use recrypt::Revealed;
-//! use recrypt::api::*;
+//!
 //! // create a new recrypt
 //! let mut recrypt = Recrypt::new();
 //!
@@ -34,8 +35,9 @@
 //! Encrypt a message to public key `initial_pub_key` and decrypt it with `target_priv_key`
 //! after transforming the encrypted message.
 //! ```
+//! use recrypt::prelude::*;
 //! use recrypt::Revealed;
-//! use recrypt::api::*;
+//!
 //! // create a new recrypt
 //! let mut recrypt = Recrypt::new();
 //!
@@ -62,7 +64,7 @@
 //!     &signing_keypair).unwrap();
 //!
 //! // Transform the plaintext to be encrypted to the target!
-//! // The data is _not_ be decrypted here. Simply transformed!
+//! // The data is _not_ decrypted here. Simply transformed!
 //! let transformed_val = recrypt.transform(
 //!     encrypted_val,
 //!     initial_to_target_transform_key,
@@ -87,6 +89,7 @@
 #[macro_use]
 extern crate proptest; // shouldn't be needed in Rust 2018, but hoping proptest will better document how to import
 
+pub mod prelude;
 #[macro_use] // this is still required in Rust 2018
 mod internal; // this needs to come before `api` as api relies on macros defined in `internal`
 pub mod api;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,3 @@
-
 //! Convenience re-export of common structs and traits needed for using Recrypt
 //!
 //! ```
@@ -9,13 +8,13 @@
 //! ```
 
 // necessary for instantiating and storing a Recrypt as a struct member
-pub use crate::api::Recrypt;
 pub use crate::api::Ed25519;
-pub use crate::api::Sha256;
 pub use crate::api::RandomBytes;
+pub use crate::api::Recrypt;
+pub use crate::api::Sha256;
 
 // traits that define functionality on Recrypt
-pub use crate::api::KeyGenOps;
 pub use crate::api::CryptoOps;
 pub use crate::api::Ed25519Ops;
+pub use crate::api::KeyGenOps;
 pub use crate::api::SchnorrOps;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,21 @@
+
+//! Convenience re-export of common structs and traits needed for using Recrypt
+//!
+//! ```
+//! use recrypt::prelude::*;
+//! use rand::rngs::ThreadRng;
+//!
+//! let recrypt: Recrypt<Sha256, Ed25519, RandomBytes<ThreadRng>> = Recrypt::new();
+//! ```
+
+// necessary for instantiating and storing a Recrypt as a struct member
+pub use crate::api::Recrypt;
+pub use crate::api::Ed25519;
+pub use crate::api::Sha256;
+pub use crate::api::RandomBytes;
+
+// traits that define functionality on Recrypt
+pub use crate::api::KeyGenOps;
+pub use crate::api::CryptoOps;
+pub use crate::api::Ed25519Ops;
+pub use crate::api::SchnorrOps;


### PR DESCRIPTION
see #63 

## Changelog:
* You can now instantiate recrypt and call all available operations, as well as store a parameterized Recrypt instance in a struct, with a single import of 
`use recrypt::prelude::*;`