### PR TITLE
The hashable instance was unused. Remove it and add a different one.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1022,7 +1022,7 @@ impl PartialEq for PublicKey {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 // If you are looking for PartialEq for PrivateKey, see PartialEq for Revealed<PrivateKey>
 pub struct PrivateKey {

--- a/src/api_480.rs
+++ b/src/api_480.rs
@@ -1058,7 +1058,7 @@ impl PartialEq for PublicKey {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 // If you are looking for PartialEq for PrivateKey, see PartialEq for Revealed<PrivateKey>
 pub struct PrivateKey {

--- a/src/internal/hashable.rs
+++ b/src/internal/hashable.rs
@@ -197,7 +197,7 @@ mod test {
     }
 
     #[test]
-    fn test_resolution(){
+    fn test_resolution() {
         let bytes = [1u8, 2u8];
         <[u8] as Hashable>::to_bytes(&bytes);
         <&[u8] as Hashable>::to_bytes(&bytes);

--- a/src/internal/hashable.rs
+++ b/src/internal/hashable.rs
@@ -33,6 +33,21 @@ where
     }
 }
 
+
+impl<T> Hashable for &[T]
+where
+    T: Hashable,
+{
+    fn to_bytes(&self) -> ByteVector {
+        let mut result: Vec<u8> = Vec::new();
+        for t in self.iter() {
+            let mut bytes = t.to_bytes();
+            result.append(&mut bytes);
+        }
+        result
+    }
+}
+
 impl<T> Hashable for Vec<T>
 where
     T: Hashable,

--- a/src/internal/hashable.rs
+++ b/src/internal/hashable.rs
@@ -195,11 +195,4 @@ mod test {
             assert_eq!(concat, vec![bv1, bv2].to_bytes());
         }
     }
-
-    #[test]
-    fn test_resolution() {
-        let bytes = [1u8, 2u8];
-        <[u8] as Hashable>::to_bytes(&bytes);
-        <&[u8] as Hashable>::to_bytes(&bytes);
-    }
 }

--- a/src/internal/hashable.rs
+++ b/src/internal/hashable.rs
@@ -33,6 +33,15 @@ where
     }
 }
 
+impl<T> Hashable for &[T]
+where
+    T: Hashable,
+{
+    fn to_bytes(&self) -> ByteVector {
+        <[T] as Hashable>::to_bytes(self)
+    }
+}
+
 impl<T> Hashable for Vec<T>
 where
     T: Hashable,
@@ -187,4 +196,10 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_resolution(){
+        let bytes = [1u8, 2u8];
+        <[u8] as Hashable>::to_bytes(&bytes);
+        <&[u8] as Hashable>::to_bytes(&bytes);
+    }
 }

--- a/src/internal/hashable.rs
+++ b/src/internal/hashable.rs
@@ -19,22 +19,7 @@ impl Hashable for u8 {
     }
 }
 
-impl<'a, T> Hashable for [&'a T]
-where
-    T: Hashable,
-{
-    fn to_bytes(&self) -> ByteVector {
-        let mut result: Vec<u8> = Vec::new();
-        for t in self.iter() {
-            let mut bytes = t.to_bytes();
-            result.append(&mut bytes);
-        }
-        result
-    }
-}
-
-
-impl<T> Hashable for &[T]
+impl<T> Hashable for [T]
 where
     T: Hashable,
 {

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -74,6 +74,13 @@ macro_rules! _bytes_core {
             new_from_slice!($t);
         }
 
+        //Allow people to consume the bytes type to get out the wrapped array.
+        impl From<$t> for [u8; $t::ENCODED_SIZE_BYTES] {
+            fn from(t: $t) -> Self {
+                t.bytes
+            }
+        }
+
         bytes_only_debug!($t);
     };
 }


### PR DESCRIPTION
We didn't actually ever use the hashable instance that had borrows in it. 

Add one for [T] and &[T] so we can support external callers using `&[u8]`