### PR TITLE
[WIP] Remove requirement for mutable refrence for api calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 rand = "~0.6"
+rand_chacha = "~0.1"
 sha2 = "~0.8"
 num-traits = "~0.2"
 lazy_static = "~1.2"
@@ -44,7 +45,7 @@ lto = true
 
 [dev-dependencies]
 proptest = "~0.9"
-rand_chacha = "~0.1"
+
 criterion = "~0.2"
 
 [features]

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,6 +23,9 @@ use core::borrow::BorrowMut;
 use gridiron::fp_256::Fp256;
 use gridiron::fp_256::Monty as Monty256;
 use rand;
+use rand::rngs::OsRng;
+use rand::SeedableRng;
+use rand_chacha;
 use std;
 use std::fmt;
 use std::ops::DerefMut;
@@ -39,13 +42,16 @@ pub struct Recrypt<H, S, R> {
     schnorr_signing: SchnorrSign<Monty256, Fr256, H>,
 }
 
-impl Recrypt<Sha256, Ed25519, RandomBytes<rand::rngs::ThreadRng>> {
-    pub fn new() -> Recrypt<Sha256, Ed25519, RandomBytes<rand::rngs::ThreadRng>> {
-        Recrypt::new_with_rand(rand::thread_rng())
+impl Recrypt<Sha256, Ed25519, RandomBytes<rand_chacha::ChaChaRng>> {
+    pub fn new() -> Recrypt<Sha256, Ed25519, RandomBytes<rand_chacha::ChaChaRng>> {
+        Recrypt::new_with_rand(
+            rand_chacha::ChaChaRng::from_rng(OsRng::new().expect("OS RNG failed to initialize."))
+                .expect("ChaChaRng failed to initialize"),
+        )
     }
 }
 
-impl Default for Recrypt<Sha256, Ed25519, RandomBytes<rand::rngs::ThreadRng>> {
+impl Default for Recrypt<Sha256, Ed25519, RandomBytes<rand_chacha::ChaChaRng>> {
     fn default() -> Self {
         Self::new()
     }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -1,0 +1,22 @@
+use rand::FromEntropy;
+use rand_chacha;
+use recrypt::prelude::*;
+use std::sync::Arc;
+use std::thread;
+#[test]
+fn generate_plaintexts() {
+    let recrypt = Arc::new(Recrypt::new_with_rand(
+        rand_chacha::ChaChaRng::from_entropy(),
+    ));
+
+    for _i in 0..10 {
+        let recrypt_ref_clone = recrypt.clone();
+        thread::spawn(move || {
+            let pt = recrypt_ref_clone.gen_plaintext();
+            dbg!(pt)
+        });
+    }
+
+    let pt = recrypt.clone().gen_plaintext();
+    dbg!(pt);
+}


### PR DESCRIPTION
This is an experiment to see if recrypt's API can be improved to replace `&mut self` -> `&self`. Initial results look promising...

## TODO
* [x] inspect performance of this approach
* [x] try recrypt from multiple threads to see if any problems present themselves
* [ ] make similar changes to 480-bit