### PR TITLE
 #80 Add features to let WASM use a 32bit backend for ed25519. Also re-enables CC on clear_on_drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.1
+
+- [[#80](#80)] Added a default set of features to enable `ed2559-dalek`s 64 bit backend and added a `wasm` feature that will instead use a 32 bit backend
+
+### Public API changes
+
+None
+
 ## 0.7.0
 
 ### Public API changes
@@ -10,14 +18,14 @@
    - `PrivateKey::ENCODED_SIZE_BYTES` is now pub
  - [[#63](#63)] Added a prelude for easier importing of common types and traits
    - `use recrypt::prelude::*`
- - [[#70](#70)] 
+ - [[#70](#70)]
    - `DerivedSymmetricKey` now has a `to_private_key`
    - `PublicKey` APIs now take all arguments as borrows
- - [[#71](#71)] 
+ - [[#71](#71)]
    - provide `From<SigningKeyPair>` instance for `[u8; 64]`
    - provide `Clone` for `PrivateKey`
    - many wrapped byte types can be consumed to get the underlying bytes out without copying
- - [[#72](#72)] `PublicSigningKey`'s `bytes()` method now returns a reference instead of copying 
+ - [[#72](#72)] `PublicSigningKey`'s `bytes()` method now returns a reference instead of copying
 
 ## 0.6.2
 
@@ -56,9 +64,9 @@
 
 ## 0.4.0
 - [#20] Update dependencies (rand 0.6, sha 0.8, ed25519 1.0.0-pre.0)
-- [#18] Add a way to hash a Plaintext to 32 bytes. 
-- [#17] Add quick_error to all of our error ADTS 
-- [#14] Add benchmarking on Travis 
+- [#18] Add a way to hash a Plaintext to 32 bytes.
+- [#17] Add quick_error to all of our error ADTS
+- [#14] Add benchmarking on Travis
 ## 0.3.0
 
 - Add hashable instance for TransformKey (#13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ rand_chacha = "~0.1"
 criterion = "~0.2"
 
 [features]
+unstable = []
 default = ["ed25519-dalek/std", "ed25519-dalek/u64_backend"]
 wasm = ["ed25519-dalek/std", "ed25519-dalek/u32_backend", "clear_on_drop/no_cc"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recrypt"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["IroncCore Labs <info at ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,13 @@ sha2 = "~0.8"
 num-traits = "~0.2"
 lazy_static = "~1.2"
 arrayvec = "~0.4"
-ed25519-dalek = "1.0.0-pre.1"
+#Disable all features for ed25519 and enable the proper ones down in the [features] section below
+ed25519-dalek = { version="1.0.0-pre.1", default-features = false }
 clear_on_drop = "~0.2"
-gridiron = "^0.6.0" 
+gridiron = "^0.6.0"
 quick-error = "~1.2"
 hex="~0.3"
 arrayref = "^0.3.5"
-
-[target.wasm32-unknown-unknown.dependencies]
-# The clear_on_drop crate, by default, implements code via C to clear memory. That doesn't work in WASM. However, they
-# have a feature to turn off requiring C which we're enabling here for WASM targets.
-clear_on_drop = {version = "0.2", features = ["no_cc"]}
 
 [profile.dev]
 opt-level = 2 # Build deps with optimization, don't build ourselves with optimization
@@ -48,7 +44,8 @@ rand_chacha = "~0.1"
 criterion = "~0.2"
 
 [features]
-unstable = []
+default = ["ed25519-dalek/std", "ed25519-dalek/u64_backend"]
+wasm = ["ed25519-dalek/std", "ed25519-dalek/u32_backend", "clear_on_drop/no_cc"]
 
 [[bench]]
 name = "api_benchmark"


### PR DESCRIPTION
Rust's dependency feature management isn't in a great place. The goal here was to allow WASM builds to use the ed25519 u32 backend and then use the u64 backend for every other build type. In order to do that we have to disable the u64 for everything and then manually re-enable it using the feature flags. Otherwise ed25519 gets built with both flags which causes a bunch of compile errors for duplicate constants. Relevant issue: https://github.com/dalek-cryptography/curve25519-dalek/issues/264

This ideally would be solved by using the architecture-detection flags (i.e. `target.'cfg(target_env = "wasm32")'.dependencies`) but that [doesn't seem to work as expected either](https://github.com/rust-lang/cargo/issues/2524).
