### PR TITLE
Update lazy_static v1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rand = "~0.6"
 rand_chacha = "~0.1"
 sha2 = "~0.8"
 num-traits = "~0.2"
-lazy_static = "~1.3"
+lazy_static = "~1.4"
 arrayvec = "~0.4"
 #Disable all features for ed25519 and enable the proper ones down in the [features] section below
 ed25519-dalek = { version="1.0.0-pre.1", default-features = false }


### PR DESCRIPTION
I have been using recrypt for various projects. Most of the other libraries are using 1.4 thus raising a version conflict issue. Here is an example, 
![image](https://user-images.githubusercontent.com/23367724/66119100-99b47700-e5f5-11e9-80e5-1be75bd818ad.png)
