### PR TITLE
Fixes a regression introduced in 0.8.0 where the randomness for some operations was reduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.8.4
+
+### Notable Internal Changes
+- Fixes a regression introduced in 0.8.0 where the randomness for some operations was reduced.
+  
+  Affected 256-bit operations in 0.8.0 through 0.8.3 were:
+  * CryptoOps::gen_plaintext
+  * CryptoOps::transform
+  * KeyGenOps::generate_transform_key
+  
+  480-bit operations were not affected.
+
 ## 0.8.3
 
 ### Notable Internal Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recrypt"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/api.rs
+++ b/src/api.rs
@@ -940,24 +940,22 @@ fn gen_random_fp12<R: RandomBytesGen>(
     pairing: &pairing::Pairing<Monty256>,
     random_bytes: &R,
 ) -> Fp12Elem<Monty256> {
-    let rand_bytes_arr = [random_bytes.random_bytes_32(); 12];
-
     // generate 12 random Fp values
     internal::gen_rth_root(
         pairing,
         Fp12Elem::create_from_t(
-            Fp256::from(rand_bytes_arr[0]),
-            Fp256::from(rand_bytes_arr[1]),
-            Fp256::from(rand_bytes_arr[2]),
-            Fp256::from(rand_bytes_arr[3]),
-            Fp256::from(rand_bytes_arr[4]),
-            Fp256::from(rand_bytes_arr[5]),
-            Fp256::from(rand_bytes_arr[6]),
-            Fp256::from(rand_bytes_arr[7]),
-            Fp256::from(rand_bytes_arr[8]),
-            Fp256::from(rand_bytes_arr[9]),
-            Fp256::from(rand_bytes_arr[10]),
-            Fp256::from(rand_bytes_arr[11]),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
+            Fp256::from(random_bytes.random_bytes_32()),
         )
         .map(&|fp256| fp256.to_monty()),
     )
@@ -1627,5 +1625,17 @@ pub(crate) mod test {
         priv_key.clear();
         assert_eq!(priv_key.bytes(), &[0u8; 32]);
         assert_eq!(priv_key._internal_key, Default::default())
+    }
+
+    #[test]
+    fn gen_random_fp12_not_same() {
+        use internal::fp::fr_256;
+        use internal::fp2elem::Fp2Elem;
+        use internal::fp6elem::Fp6Elem;
+
+        let recrypt = Recrypt::new();
+        let fp12_one = gen_random_fp12(&recrypt.pairing, &recrypt.random_bytes);
+        let fp12_two = gen_random_fp12(&recrypt.pairing, &recrypt.random_bytes);
+        assert_ne!(fp12_one, fp12_two);
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1629,10 +1629,6 @@ pub(crate) mod test {
 
     #[test]
     fn gen_random_fp12_not_same() {
-        use internal::fp::fr_256;
-        use internal::fp2elem::Fp2Elem;
-        use internal::fp6elem::Fp6Elem;
-
         let recrypt = Recrypt::new();
         let fp12_one = gen_random_fp12(&recrypt.pairing, &recrypt.random_bytes);
         let fp12_two = gen_random_fp12(&recrypt.pairing, &recrypt.random_bytes);


### PR DESCRIPTION
Affected 256-bit operations in 0.8.0 through 0.8.3 were:
* `CryptoOps::gen_plaintext`
* `CryptoOps::transform`
* `KeyGenOps::generate_transform_key`

480-bit operations were not affected.