### PR TITLE
Fix ed25519 to pre1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.36.0
+  - 1.39.0
 # hopefully prevent the cache from becoming huge - https://levans.fr/rust_travis_cache.html
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.39.0
+  - 1.36.0
 # hopefully prevent the cache from becoming huge - https://levans.fr/rust_travis_cache.html
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Notable internal changes
 
-- Fix the dependency pinning for ed25519 to be exact.
+- [#98](#98)
+  - Fix the dependency pinning for ed25519 to be exact.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.1
+
+### Notable internal changes
+
+- Fix the dependency pinning for ed25519 to be exact.
+
 ## 0.9.0
 
 ### Public API changes
@@ -11,13 +17,15 @@
 ## 0.8.4
 
 ### Notable Internal Changes
+
 - Fixes a regression introduced in 0.8.0 where the randomness for some operations was reduced.
-  
+
   Affected 256-bit operations in 0.8.0 through 0.8.3 were:
-  * CryptoOps::gen_plaintext
-  * CryptoOps::transform
-  * KeyGenOps::generate_transform_key
-  
+
+  - CryptoOps::gen_plaintext
+  - CryptoOps::transform
+  - KeyGenOps::generate_transform_key
+
   480-bit operations were not affected.
 
 ## 0.8.3
@@ -58,21 +66,22 @@ Bumped lazy_static version to 1.3.
 ## 0.7.0
 
 ### Public API changes
- - [[#57](#57)]
-   - `api::Api` renamed to `api::Recrypt`
-   - `api_480::Api480` renamed to `api_480::Recrypt480`
-   - `ApiErr` renamed to `RecryptErr` and `RecryptErr` is now publicly exported
-   - `PrivateKey::ENCODED_SIZE_BYTES` is now pub
- - [[#63](#63)] Added a prelude for easier importing of common types and traits
-   - `use recrypt::prelude::*`
- - [[#70](#70)]
-   - `DerivedSymmetricKey` now has a `to_private_key`
-   - `PublicKey` APIs now take all arguments as borrows
- - [[#71](#71)]
-   - provide `From<SigningKeyPair>` instance for `[u8; 64]`
-   - provide `Clone` for `PrivateKey`
-   - many wrapped byte types can be consumed to get the underlying bytes out without copying
- - [[#72](#72)] `PublicSigningKey`'s `bytes()` method now returns a reference instead of copying
+
+- [[#57](#57)]
+  - `api::Api` renamed to `api::Recrypt`
+  - `api_480::Api480` renamed to `api_480::Recrypt480`
+  - `ApiErr` renamed to `RecryptErr` and `RecryptErr` is now publicly exported
+  - `PrivateKey::ENCODED_SIZE_BYTES` is now pub
+- [[#63](#63)] Added a prelude for easier importing of common types and traits
+  - `use recrypt::prelude::*`
+- [[#70](#70)]
+  - `DerivedSymmetricKey` now has a `to_private_key`
+  - `PublicKey` APIs now take all arguments as borrows
+- [[#71](#71)]
+  - provide `From<SigningKeyPair>` instance for `[u8; 64]`
+  - provide `Clone` for `PrivateKey`
+  - many wrapped byte types can be consumed to get the underlying bytes out without copying
+- [[#72](#72)] `PublicSigningKey`'s `bytes()` method now returns a reference instead of copying
 
 ## 0.6.2
 
@@ -90,30 +99,38 @@ Bumped lazy_static version to 1.3.
 - [[#52](#52)] Update to use Monty represenation for all 480 bit operations.
 
 ## 0.6.0
+
 ### Public API changes
-  * [[#35](#35)] 480-bit public API available. See api_480.rs
+
+- [[#35](#35)] 480-bit public API available. See api_480.rs
+
 ### Notable Internal Changes
+
 - [[#27](#27)] Use Rust 2018 edition
 - Progress toward Constant Time algorithms
-  * [[#42](#42)] Fp `is_one` and `is_zero` documented to not be constant time
-  * [[#40](#40)] Fp `Mul<u64>` and `Add<u64>` now use `u32` and are documented to not be constant time
-  * [[#39](#39)] Point negation is constant time
-  * [[#37](#37)] Fp12/6 `to_fp2` constant time behavior documented
-  * [[#26](#26)] Point double and add functions are constant time
+  - [[#42](#42)] Fp `is_one` and `is_zero` documented to not be constant time
+  - [[#40](#40)] Fp `Mul<u64>` and `Add<u64>` now use `u32` and are documented to not be constant time
+  - [[#39](#39)] Point negation is constant time
+  - [[#37](#37)] Fp12/6 `to_fp2` constant time behavior documented
+  - [[#26](#26)] Point double and add functions are constant time
 
 ## 0.5.1
+
 - [[#24](#24)] Added better errors for Ed25519 and NonEmptyVec
 
 ## 0.5.0
+
 - [[#21](#21)] Consume gridiron 0.4.0 (primatives are now constant time)
-  * `NonAdjacentForm` renamed to `BitRepr`
-  * Upgrade to Rust 1.31.0
+  - `NonAdjacentForm` renamed to `BitRepr`
+  - Upgrade to Rust 1.31.0
 
 ## 0.4.0
+
 - [#20] Update dependencies (rand 0.6, sha 0.8, ed25519 1.0.0-pre.0)
 - [#18] Add a way to hash a Plaintext to 32 bytes.
 - [#17] Add quick_error to all of our error ADTS
 - [#14] Add benchmarking on Travis
+
 ## 0.3.0
 
 - Add hashable instance for TransformKey (#13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "~0.2"
 lazy_static = "~1.4"
 arrayvec = "~0.4"
 #Disable all features for ed25519 and enable the proper ones down in the [features] section below
-ed25519-dalek = { version="1.0.0-pre.1", default-features = false }
+ed25519-dalek = { version="=1.0.0-pre.1", default-features = false }
 clear_on_drop = "~0.2"
 gridiron = "^0.6.0"
 quick-error = "~1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recrypt"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
- We weren't properly pinning to pre1, we should be because pre3 is on rand 0.7
- Only changes to changelog are the 0.9.1 section, but I fixed the formatting for the rest of the CHANGELOG.