### PR TITLE
Add Clone to Plaintext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.2
+
+### Public API changes
+
+- [#99](#99)
+  - Provide `Clone` for `Plaintext`
+
 ## 0.9.1
 
 ### Notable internal changes

--- a/src/api.rs
+++ b/src/api.rs
@@ -99,8 +99,7 @@ new_bytes_type!(EncryptedMessage, Fp12Elem::<Monty256>::ENCODED_SIZE_BYTES);
 
 // Not hashed, not encrypted Fp12Elem
 // See DecryptedSymmetricKey and EncryptedMessage
-// we don't derive Copy or Clone here on purpose. Plaintext is a sensitive value and should be passed by reference
-// to avoid needless duplication
+#[derive(Clone)]
 pub struct Plaintext {
     bytes: [u8; Plaintext::ENCODED_SIZE_BYTES],
     _internal_fp12: Fp12Elem<Monty256>,


### PR DESCRIPTION
Need clone on plaintext for making a MockCryptoOps in ironoxide. We already have clone on PrivateKey, so it makes sense to be consistent here anyway.