### PR TITLE
Add Hash and Eq to all types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## NEXT RELEASE
+## 0.10.0
 
 ### Public API changes
+
+- [[#104](https://github.com/IronCoreLabs/recrypt-rs/pull/104)]
+
+  - Eliminate the `Revealed` struct.
+  - Add `Hash` for all public types except `Recrypt`.
+  - Add `Eq` for all types which had `PartialEq`.
 
 - [[#101](https://github.com/IronCoreLabs/recrypt-rs/pull/101)]
   - Eliminate the `Revealed` wrappers for `PrivateKey`, `Plaintext`, and `DerivedSymmetricKey`.
@@ -11,8 +17,13 @@
 ### Notable internal changes
 
 - [[#101](https://github.com/IronCoreLabs/recrypt-rs/pull/101)]
+
   - Eliminate the `Revealed` wrapper for `SigningKeypair`.
   - Implement `PartialEq` for `SigningKeypair`.
+
+- [[#104](https://github.com/IronCoreLabs/recrypt-rs/pull/104)]
+  - Move to use constant time eq for all properties that have `bytes()`.
+  - Use derivative to derive `PartialEq` and `Hash` instead of hand crafted implementations.
 
 ## 0.9.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recrypt"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ quick-error = "~1.2"
 hex="~0.3"
 arrayref = "^0.3.5"
 log = "~0.4"
+derivative = "1.0.3"
 
 [profile.dev]
 opt-level = 2 # Build deps with optimization, don't build ourselves with optimization

--- a/src/api.rs
+++ b/src/api.rs
@@ -628,6 +628,8 @@ impl PartialEq for TransformKey {
             && self.signature == other.signature
     }
 }
+impl Eq for TransformKey {}
+
 impl Hash for TransformKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.ephemeral_public_key.hash(state);

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,7 +19,7 @@ pub use crate::internal::sha256::{Sha256, Sha256Hashing};
 pub use crate::internal::ByteVector;
 use crate::nonemptyvec::NonEmptyVec;
 use clear_on_drop::clear::Clear;
-use derivative::*;
+use derivative::Derivative;
 use gridiron::fp_256::Fp256;
 use gridiron::fp_256::Monty as Monty256;
 use rand;
@@ -173,8 +173,7 @@ pub struct TransformBlock {
     random_transform_public_key: PublicKey,
     /// encrypted temp key value. Used to go from the transformed value to the encrypted value
     encrypted_random_transform_temp_key: EncryptedTempKey,
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
     _internal_re_block: internal::ReencryptionBlock<Monty256>,
 }
 
@@ -505,8 +504,7 @@ pub struct TransformKey {
     hashed_temp_key: HashedValue,
     public_signing_key: PublicSigningKey,
     signature: Ed25519Signature,
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
     _internal_key: internal::SignedValue<internal::ReencryptionKey<Monty256>>,
 }
 
@@ -922,8 +920,7 @@ fn gen_random_fp12<R: RandomBytesGen>(
 pub struct PublicKey {
     x: [u8; 32],
     y: [u8; 32],
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
     _internal_key: internal::PublicKey<Monty256>,
 }
 

--- a/src/api_480.rs
+++ b/src/api_480.rs
@@ -79,15 +79,7 @@ impl<CR: rand::CryptoRng + rand::RngCore> Recrypt480<Sha256, Ed25519, RandomByte
 }
 
 // Hashed but not encrypted Plaintext used for envelope encryption
-new_bytes_type_no_eq!(DerivedSymmetricKey, 32);
-
-// Constant-time data-invariant implementation of eq for DerivedSymmetricKey.
-impl PartialEq for DerivedSymmetricKey {
-    fn eq(&self, other: &DerivedSymmetricKey) -> bool {
-        let byte_pairs = self.bytes.iter().zip(other.bytes.iter());
-        byte_pairs.fold(0, |acc, (next_a, next_b)| acc | (next_a ^ next_b)) == 0
-    }
-}
+new_bytes_type_no_copy!(DerivedSymmetricKey, 32);
 
 // A value included in an encrypted message that can be used when the message is decrypted
 // to ensure that you got the same value out as the one that was originally encrypted.
@@ -1618,5 +1610,4 @@ pub(crate) mod test {
         assert_ne!(dk1, dk2);
         Ok(())
     }
-
 }

--- a/src/api_480.rs
+++ b/src/api_480.rs
@@ -19,7 +19,7 @@ pub use crate::internal::sha256::{Sha256, Sha256Hashing};
 pub use crate::internal::ByteVector;
 use crate::nonemptyvec::NonEmptyVec;
 use clear_on_drop::clear::Clear;
-use derivative::*;
+use derivative::Derivative;
 use gridiron::fp_480::Fp480;
 use gridiron::fp_480::Monty as Monty480;
 use rand;
@@ -172,8 +172,7 @@ pub struct TransformBlock {
     random_transform_public_key: PublicKey,
     /// encrypted temp key value. Used to go from the transformed value to the encrypted value
     encrypted_random_transform_temp_key: EncryptedTempKey,
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
     _internal_re_block: internal::ReencryptionBlock<Monty480>,
 }
 
@@ -505,8 +504,7 @@ pub struct TransformKey {
     hashed_temp_key: HashedValue,
     public_signing_key: PublicSigningKey,
     signature: Ed25519Signature,
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
     _internal_key: internal::SignedValue<internal::ReencryptionKey<Monty480>>,
 }
 
@@ -954,8 +952,7 @@ bytes_eq_and_hash!(SixtyBytes);
 pub struct PublicKey {
     x: SixtyBytes,
     y: SixtyBytes,
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
     _internal_key: internal::PublicKey<Monty480>,
 }
 

--- a/src/api_480.rs
+++ b/src/api_480.rs
@@ -19,6 +19,7 @@ pub use crate::internal::sha256::{Sha256, Sha256Hashing};
 pub use crate::internal::ByteVector;
 use crate::nonemptyvec::NonEmptyVec;
 use clear_on_drop::clear::Clear;
+use derivative::*;
 use gridiron::fp_480::Fp480;
 use gridiron::fp_480::Monty as Monty480;
 use rand;
@@ -27,8 +28,6 @@ use rand::rngs::EntropyRng;
 use rand::FromEntropy;
 use std;
 use std::fmt;
-use std::hash::{Hash, Hasher};
-
 /// Recrypt public API - 480-bit
 /// If you are looking better performance, you might consider the 256-bit API in `api.rs`
 #[derive(Debug)]
@@ -162,7 +161,8 @@ impl Hashable for Plaintext {
 }
 
 /// Describes a single transform. Multiple `TransformBlocks` (in series) describe multi-hop transforms.
-#[derive(Debug, Clone, Copy)]
+#[derivative(PartialEq, Eq, Hash)]
+#[derive(Derivative, Debug, Clone, Copy)]
 pub struct TransformBlock {
     /// public key corresponding to private key used to encrypt the temp key.
     public_key: PublicKey,
@@ -172,6 +172,8 @@ pub struct TransformBlock {
     random_transform_public_key: PublicKey,
     /// encrypted temp key value. Used to go from the transformed value to the encrypted value
     encrypted_random_transform_temp_key: EncryptedTempKey,
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     _internal_re_block: internal::ReencryptionBlock<Monty480>,
 }
 
@@ -221,24 +223,6 @@ impl TransformBlock {
     }
 }
 
-impl PartialEq for TransformBlock {
-    fn eq(&self, other: &TransformBlock) -> bool {
-        self.public_key == other.public_key
-            && self.encrypted_temp_key == other.encrypted_temp_key
-            && self.random_transform_public_key == other.random_transform_public_key
-            && self.encrypted_random_transform_temp_key == other.encrypted_random_transform_temp_key
-    }
-}
-impl Eq for TransformBlock {}
-
-impl Hash for TransformBlock {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.public_key.hash(state);
-        self.encrypted_temp_key.hash(state);
-        self.random_transform_public_key.hash(state);
-        self.encrypted_random_transform_temp_key.hash(state);
-    }
-}
 /// Encrypted value that is either initially encrypted or one that has been
 /// transformed one or more times
 #[derive(Debug, Clone, PartialEq)] //cannot derive Copy because of NonEmptyVec
@@ -512,7 +496,8 @@ impl From<TwistedHPoint<Monty480>> for HashedValue {
 /// `to_public_key`         - public key of the delagatee
 /// `encrypted_k`           - random value K, encrypted to the delegatee; used to un-roll successive levels of multi-hop transform encryption
 /// `hashed_k`              - combination of the hash of K and the secret key of the delegator; used to recover K from `encrypted_k`
-#[derive(Debug, Clone)] //can't derive Copy because of NonEmptyVec
+#[derivative(PartialEq, Eq, Hash)]
+#[derive(Derivative, Debug, Clone)] //can't derive Copy because of NonEmptyVec
 pub struct TransformKey {
     ephemeral_public_key: PublicKey,
     to_public_key: PublicKey,
@@ -520,6 +505,8 @@ pub struct TransformKey {
     hashed_temp_key: HashedValue,
     public_signing_key: PublicSigningKey,
     signature: Ed25519Signature,
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     _internal_key: internal::SignedValue<internal::ReencryptionKey<Monty480>>,
 }
 
@@ -615,29 +602,6 @@ impl TransformKey {
             payload: new_internal,
             ..self._internal_key
         })
-    }
-}
-impl PartialEq for TransformKey {
-    fn eq(&self, other: &TransformKey) -> bool {
-        self.ephemeral_public_key == other.ephemeral_public_key
-            && self.to_public_key == other.to_public_key
-            && self.encrypted_temp_key == other.encrypted_temp_key
-            && self.hashed_temp_key == other.hashed_temp_key
-            && self.public_signing_key == other.public_signing_key
-            && self.signature == other.signature
-    }
-}
-
-impl Eq for TransformKey {}
-
-impl Hash for TransformKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.ephemeral_public_key.hash(state);
-        self.to_public_key.hash(state);
-        self.encrypted_temp_key.hash(state);
-        self.hashed_temp_key.hash(state);
-        self.public_signing_key.hash(state);
-        self.signature.hash(state);
     }
 }
 
@@ -985,10 +949,13 @@ impl Default for SixtyBytes {
 
 bytes_eq_and_hash!(SixtyBytes);
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Derivative, Debug, Clone, Copy)]
+#[derivative(PartialEq, Hash, Eq)]
 pub struct PublicKey {
     x: SixtyBytes,
     y: SixtyBytes,
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     _internal_key: internal::PublicKey<Monty480>,
 }
 
@@ -1059,22 +1026,6 @@ impl PublicKey {
         PublicKey::try_from(&internal::PublicKey::new(new_point))
     }
 }
-
-impl Hash for PublicKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        let (x_bytes, y_bytes) = self.bytes_x_y();
-        for x in x_bytes.iter().chain(y_bytes.iter()) {
-            x.hash(state)
-        }
-    }
-}
-
-impl PartialEq for PublicKey {
-    fn eq(&self, other: &PublicKey) -> bool {
-        self.x == other.x && self.y == other.y
-    }
-}
-impl Eq for PublicKey {}
 
 #[derive(Default, Debug, Clone)]
 pub struct PrivateKey {

--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -125,14 +125,7 @@ impl SigningKeypair {
         Ed25519.sign(message, self)
     }
 }
-
-// Constant-time data-invariant implementation of eq for SigningKeyPair, which includes a private key.
-impl PartialEq for SigningKeypair {
-    fn eq(&self, other: &SigningKeypair) -> bool {
-        let byte_pairs = self.bytes.iter().zip(other.bytes.iter());
-        byte_pairs.fold(0, |acc, (next_a, next_b)| acc | (next_a ^ next_b)) == 0
-    }
-}
+bytes_eq_and_hash!(SigningKeypair);
 
 impl<'a> From<&'a SigningKeypair> for PublicSigningKey {
     fn from(kp: &SigningKeypair) -> PublicSigningKey {

--- a/src/internal/fp2elem.rs
+++ b/src/internal/fp2elem.rs
@@ -388,7 +388,7 @@ pub mod test {
             elem1: Fp256::from(4u32),
             elem2: Fp256::from(2u32),
         };
-        let fp2_monty = fp2.map(&|fp| fp.to_monty());;
+        let fp2_monty = fp2.map(&|fp| fp.to_monty());
         let five_times = fp2 * fp2 * fp2 * fp2 * fp2;
         let five_times_monty = fp2_monty * fp2_monty * fp2_monty * fp2_monty * fp2_monty;
         assert_eq!(five_times_monty, five_times.map(&|fp| fp.to_monty()));
@@ -401,7 +401,7 @@ pub mod test {
             elem1: Fp256::from(4u32),
             elem2: Fp256::from(2u32),
         };
-        let fp2_monty = fp2.map(&|fp| fp.to_monty());;
+        let fp2_monty = fp2.map(&|fp| fp.to_monty());
         let five_times_monty = fp2_monty * fp2_monty * fp2_monty * fp2_monty * fp2_monty;
         assert_eq!(five_times_monty, fp2_monty.pow(five));
     }

--- a/src/internal/homogeneouspoint.rs
+++ b/src/internal/homogeneouspoint.rs
@@ -572,7 +572,7 @@ pub mod test {
                 "0000000000000000000000000000000000000000000000000000000000000040",
             ),
         }
-        .map(&|fp: gridiron::fp_256::Fp256| fp.to_monty());;
+        .map(&|fp: gridiron::fp_256::Fp256| fp.to_monty());
 
         let computed_g2 = FP_256_CURVE_POINTS.generator + FP_256_CURVE_POINTS.generator;
         assert_eq!(g2, computed_g2);

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -60,7 +60,7 @@ macro_rules! bytes_eq_and_hash {
 
         impl std::hash::Hash for $t {
             fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-                self.bytes.len().hash(state);
+                self.bytes().len().hash(state);
                 std::hash::Hash::hash_slice(&self.bytes()[..], state)
             }
         }

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -46,16 +46,24 @@ macro_rules! _bytes_struct {
     };
 }
 
-macro_rules! _bytes_eq {
+macro_rules! bytes_eq_and_hash {
     ($t: ident) => {
-        // PartialEq and Eq are Not constant time
+        // Constant time eq
         impl PartialEq for $t {
             fn eq(&self, other: &$t) -> bool {
-                self.bytes[..] == other.bytes[..]
+                let byte_pairs = self.bytes().iter().zip(other.bytes().iter());
+                byte_pairs.fold(0, |acc, (next_a, next_b)| acc | (next_a ^ next_b)) == 0
             }
         }
 
         impl Eq for $t {}
+
+        impl std::hash::Hash for $t {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.bytes.len().hash(state);
+                std::hash::Hash::hash_slice(&self.bytes()[..], state)
+            }
+        }
     };
 }
 
@@ -90,23 +98,15 @@ macro_rules! new_bytes_type {
     ($t: ident, $n: expr) => {
         _bytes_struct!($t, derive(Copy, Clone));
         _bytes_core!($t, $n);
-        _bytes_eq!($t);
-    };
-    ($t: ident, $n: expr, $derive: meta) => {
-        _bytes_struct!($t, $n, $derive);
-        _bytes_core!($t, $n);
-        _bytes_eq!($t);
+        bytes_eq_and_hash!($t);
     };
 }
 
-macro_rules! new_bytes_type_no_eq {
+macro_rules! new_bytes_type_no_copy {
     ($t: ident, $n: expr) => {
-        _bytes_struct!($t, derive(Copy, Clone));
+        _bytes_struct!($t, derive(Clone));
         _bytes_core!($t, $n);
-    };
-    ($t: ident, $n: expr, $derive: meta) => {
-        _bytes_struct!($t, $n, $derive);
-        _bytes_core!($t, $n);
+        bytes_eq_and_hash!($t);
     };
 }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1359,7 +1359,7 @@ mod test {
                 fp256_unsafe_from("5404b493123a5b087cb6cc363116a9fc393c27dac3efa3df778ec974b8bdfa76"),
                 //49941783284737700171954796486309114156831309184207470337019703077683277143423
                 fp256_unsafe_from("6e6a0c315c47fa2990268bc2010eeda17b78cc32e7ab6f093bf1aa2234491d7f")
-            ) .map(&|fp| fp.to_monty());;
+            ) .map(&|fp| fp.to_monty());
 
             let good_hashed_k = TwistedHPoint {
                 x: fp2elem::Fp2Elem {
@@ -1380,7 +1380,7 @@ mod test {
                     //18358874287282838450918898019272385250887285769392485811015731318886010089831
                     elem2: fp256_unsafe_from("2896c12e42c82648d4e553e82b32abe95618f0e5ad7f8ba14d6180b78ae67167")
                 }
-            } .map(&|fp| fp.to_monty());;
+            } .map(&|fp| fp.to_monty());
 
             assert_eq!(good_encrypted_k, re_key.encrypted_k);
             assert_eq!(good_hashed_k, re_key.hashed_k)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,3 @@ pub mod api;
 pub mod api_480;
 mod api_common;
 pub mod nonemptyvec;
-
-/// Marker struct to show potential weakness to side-channel attacks for normally secure types.
-/// Never wrapped around u8, u32, u64 as those are always assumed to be revealed.
-#[derive(Debug)]
-pub struct Revealed<T>(pub T);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ## Basic Encrypt/Decrypt Example
 //! ```
 //! use recrypt::prelude::*;
-//! use recrypt::Revealed;
+
 //!
 //! // create a new recrypt
 //! let mut recrypt = Recrypt::new();
@@ -36,7 +36,6 @@
 //! after transforming the encrypted message.
 //! ```
 //! use recrypt::prelude::*;
-//! use recrypt::Revealed;
 //!
 //! // create a new recrypt
 //! let mut recrypt = Recrypt::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,9 +80,7 @@
 //!
 //! We have done a lot of work in recrypt-rs to ensure that operations dealing with secret data
 //! are [constant time](https://www.bearssl.org/constanttime.html) and not susceptible to [timing attacks](https://en.wikipedia.org/wiki/Timing_attack).
-//! The public API is also constant time, except for equality. In the future we might implement
-//! constant time `PartialEq`, but until then secret API values (`Plaintext`, `PrivateKey`, `DerivedSymmetricKey`)
-//! have equality only when wrapped in the `Revealed` type.
+//! The public API is also constant time.
 
 pub mod prelude;
 #[macro_use] // this is still required in Rust 2018

--- a/src/nonemptyvec.rs
+++ b/src/nonemptyvec.rs
@@ -1,5 +1,4 @@
 use quick_error::quick_error;
-use std::hash::Hash;
 
 /// A simple-minded NonEmptyVec implementation
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]

--- a/src/nonemptyvec.rs
+++ b/src/nonemptyvec.rs
@@ -1,7 +1,8 @@
 use quick_error::quick_error;
+use std::hash::Hash;
 
 /// A simple-minded NonEmptyVec implementation
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct NonEmptyVec<T> {
     first: T,
     rest: Vec<T>,


### PR DESCRIPTION
 TODO

- [ ] api_480 types.


I implemented Hash and Eq for all the public types. I used the following criteria for my implementations:
- Any bytes types can use a generic implementation in the macro
- Any types that has an internal type and a bytes property, I used the bytes property
- Any types that could derive Hash, I used it

I also made all types that have `bytes` use the constant time eq functions just to eliminate duplicate code.