### PR TITLE
Add explicit 32-bit mode as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,10 @@ criterion = "~0.2"
 
 [features]
 unstable = []
-default = ["ed25519-dalek/u64_backend"]
-u32 = ["ed25519-dalek/u32_backend"]
-wasm = ["ed25519-dalek/u32_backend", "clear_on_drop/no_cc", "getrandom/wasm-bindgen"]
+default = ["u64_backend"]
+u64_backend = ["ed25519-dalek/u64_backend"]
+u32_backend = ["ed25519-dalek/u32_backend"]
+wasm = ["u32_backend", "clear_on_drop/no_cc", "getrandom/wasm-bindgen"]
 
 [[bench]]
 name = "api_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ criterion = "~0.2"
 [features]
 unstable = []
 default = ["ed25519-dalek/u64_backend"]
+u32 = ["ed25519-dalek/u32_backend"]
 wasm = ["ed25519-dalek/u32_backend", "clear_on_drop/no_cc", "getrandom/wasm-bindgen"]
 
 [[bench]]


### PR DESCRIPTION
The need for this feature arose from testing performed in https://github.com/IronCoreLabs/recrypt-rs/issues/112

This will allow 3rd-party applications the flexibility to choose different build combinations (32-bit, 64-bit or wasm)

For example, 3rd-party applications will be able to use the [newly proposed optional Serde feature](https://github.com/IronCoreLabs/recrypt-rs/pull/109) (once implemented) via 32-bit, 64-bit or wasm i.e.

Adding the optional Serde feature - 64-bit + serde
```
[dependencies]
recrypt = { version = "~0.11.0", features = ["serde"] } 
```
Adding the optional Serde feature - 32-bit + serde
```
[dependencies]
recrypt = { version = "~0.11.0", features = ["serde", "u32"], default-features = false } 
```
Adding the optional Serde feature - wasm +serde
```
[dependencies]
recrypt = { version = "~0.11.0", features = ["serde", "wasm"], default-features = false } 
```

One of the main drivers for this additional explicit 32-bit mode is that 3rd-party Rust applications (which use recrypt) are not able to perform the following long-hand dependency declaration in their Cargo.toml
```
recrypt = { version = "~0.11.0", features = ["ed25519-dalek/u32_backend"] } 
```
The above causes the following error
```
error: feature names may not contain slashes: `ed25519-dalek/u32_backend`
```