### PR TITLE
Fail fast if rustfmt errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,9 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+      - name: Cancel workflow
+        if: failure()
+        uses: andymckay/cancel-action@0.2
 
   # Build on all the architectures we intend to support, including cross compiled ones.
   build:

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,7 @@
 //! ```
 
 // necessary for instantiating and storing a Recrypt as a struct member
- pub use crate::api::Ed25519;
+pub use crate::api::Ed25519;
 pub use crate::api::RandomBytes;
 pub use crate::api::Recrypt;
 pub use crate::api::Sha256;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,7 @@
 //! ```
 
 // necessary for instantiating and storing a Recrypt as a struct member
-pub use crate::api::Ed25519;
+ pub use crate::api::Ed25519;
 pub use crate::api::RandomBytes;
 pub use crate::api::Recrypt;
 pub use crate::api::Sha256;


### PR DESCRIPTION
Testing CI behavior. Rustfmt runs as a separate job, parallel to the other ones. If it fails, does it immediately cancel the whole build? Does it email immediately?

~~I'll delete this branch and PR once we know the answers.~~