### PR TITLE
Some benchmarks are better than none.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,3 +115,103 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
+  # Benchmark current and base revisions, if this is a PR.
+  bench:
+    name: Bench
+    runs-on: ubuntu-18.04
+    if: github.base_ref != ''
+    strategy:
+      matrix:
+        include:
+          - name: current
+            ref: ${{ github.ref }}
+          - name: base
+            ref: ${{ github.base_ref }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.ref }}
+      # Work around https://github.com/actions/cache/issues/133#issuecomment-599102035
+      - run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
+        name: Fix perms on .cargo so we can restore the cache.
+      - name: Cache cargo
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/
+          key: ${{ github.job }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ github.job }}-${{ runner.os }}-target-${{ hashFiles('**/Cargo.toml') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: critcmp
+      - uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: -- --save-baseline ${{ matrix.name }}
+      - run: critcmp --export ${{ matrix.name }} > results.json
+      - name: Store benchmark results
+        uses: actions/upload-artifact@v1
+        with:
+          name: bench-${{ matrix.name }}
+          path: results.json
+
+  # Add a comment to the PR with benchmark results. Only if everything else passed, and this is a PR.
+  bench_results:
+    needs:
+      - bench
+    name: Upload benchmark results
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      # Work around https://github.com/actions/cache/issues/133#issuecomment-599102035
+      - run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
+        name: Fix perms on .cargo so we can restore the cache.
+      - name: Cache cargo
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/
+          key: ${{ github.job }}
+      - name: Retrieve benchmark results
+        uses: actions/download-artifact@v1
+        with:
+          name: bench-current
+      - name: Retrieve benchmark results
+        uses: actions/download-artifact@v1
+        with:
+          name: bench-base
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: critcmp
+      - name: Compare benchmarks
+        run: |
+          if ! critcmp bench-base/results.json bench-current/results.json -t 10 ; then
+            echo "# Benchmark blew big budget! Bad!" > comment.md
+          fi
+          echo "Benchmark results comparing with base:" >> comment.md
+          echo '```' >> comment.md
+          critcmp bench-base/results.json bench-current/results.json -t 2 >> comment.md || true
+          echo '```' >> comment.md
+          mv comment.md .github/workflows/comment.md
+          cat comment.md
+      # This will post a comment to the PR with benchmark results, but it's disabled because it's annoying.
+      # - uses: harupy/comment-on-pr@c0522c4
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     filename: comment.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,8 +207,8 @@ jobs:
           echo '```' >> comment.md
           critcmp bench-base/results.json bench-current/results.json -t 2 >> comment.md || true
           echo '```' >> comment.md
-          mv comment.md .github/workflows/comment.md
           cat comment.md
+          mv comment.md .github/workflows/comment.md
       # This will post a comment to the PR with benchmark results, but it's disabled because it's annoying.
       # - uses: harupy/comment-on-pr@c0522c4
       #   env:


### PR DESCRIPTION
This sort of resurrects #117. Posting comments to the PR is disabled, but it still builds and runs the benchmarks; and it cats the output into the build log.