### PR TITLE
Bump MSRV to 1.41.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.40.0 #MSRV
+          - 1.41.1 #MSRV
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Necessary because one of our transitive dependencies requires 1.41: https://github.com/dalek-cryptography/subtle#minimum-supported-rust-version