### PR TITLE
Swap to ed25519-dalek-fiat from ed25519-dalek

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target=${{ matrix.target }} --features=${{ matrix.features }}
+          args: --release --target=${{ matrix.target }} ${{ matrix.features }}
 
   # Run the tests on only one architecture, against various Rust versions.
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target=${{ matrix.target }}
+          args: --release --target=${{ matrix.target }} --features=${{ matrix.features }}
 
   # Run the tests on only one architecture, against various Rust versions.
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.48 #MSRV
+          - 1.51 #MSRV
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ winapi = { version = "0.3", features = [ "memoryapi", "sysinfoapi" ] }
 [dependencies]
 #Explicit dependency so we can pass the wasm-bindgen flag to it
 getrandom = {version = "~0.2.0", optional = true}
-rand = "~0.7.3"
-rand_chacha = "~0.2.2"
+rand = "~0.8.4"
+rand_chacha = "~0.3.1"
 sha2 = "~0.9"
 num-traits = "~0.2"
 lazy_static = "~1.4"
 #Disable all features for ed25519 and enable the proper ones down in the [features] section below
-ed25519-dalek = { version="=1.0.1", default-features = false, features = ["std"] }
+ed25519-dalek = { version="=0.1.0", default-features = false, features = ["std"], package = "ed25519-dalek-fiat" }
 clear_on_drop = "~0.2"
-gridiron = "~0.8.0"
+gridiron = "~0.9.0"
 quick-error = "~2.0"
 hex="~0.4"
 arrayref = "^0.3.5"


### PR DESCRIPTION
API compatible, just a change in the toml file. Whether that project's direction aligns or not is unknown, but the fiat backends are being brought in to the normal curve25519 project under dalek crypto.