### PR TITLE
Use try_from to avoid having to import Signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
 name = "recrypt"
-version = "0.13.0"
+version = "0.13.1"
 authors = [ "IronCore Labs <info@ironcorelabs.com>" ]
 readme = "README.md"
 license = "AGPL-3.0-only"
 repository = "https://github.com/IronCoreLabs/recrypt-rs"
 documentation = "https://docs.rs/recrypt"
 categories = [ "cryptography", "algorithms" ]
-keywords = [ "cryptography", "proxy-re-encryption", "PRE", "ECC", "transform-encryption" ]
+keywords = [
+    "cryptography",
+    "proxy-re-encryption",
+    "PRE",
+    "ECC",
+    "transform-encryption",
+]
 description = "A pure-Rust implementation of Transform Encryption, a Proxy Re-encryption scheme"
 edition = "2021"
 rust-version = "1.56.0"
@@ -23,11 +29,13 @@ cfg-if = "1"
 clear_on_drop = "0.2"
 derivative = "2.1"
 # Disable all features for ed25519 and enable the proper ones down in the [features] section below
-ed25519-dalek = { version="=0.1.0", default-features = false, features = [ "std" ], package = "ed25519-dalek-fiat" }
+ed25519-dalek = { version = "=0.1.0", default-features = false, features = [
+    "std",
+], package = "ed25519-dalek-fiat" }
 # Explicit dependency so we can pass the wasm-bindgen flag to it
 getrandom = { version = "0.2", optional = true }
 gridiron = "0.10"
-hex="0.4"
+hex = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 num-traits = "0.2"
@@ -60,7 +68,7 @@ u64_backend = [ "ed25519-dalek/u64_backend" ]
 u32_backend = [ "ed25519-dalek/u32_backend" ]
 wasm = [ "u32_backend", "clear_on_drop/no_cc", "getrandom/js" ]
 #Can be used to disable the automatic mlock detection for architectures.
-disable_memlock = [ ]
+disable_memlock = []
 
 [[bench]]
 name = "api_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,39 +1,31 @@
 [package]
 name = "recrypt"
 version = "0.13.1"
-authors = [ "IronCore Labs <info@ironcorelabs.com>" ]
+authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"
 repository = "https://github.com/IronCoreLabs/recrypt-rs"
 documentation = "https://docs.rs/recrypt"
-categories = [ "cryptography", "algorithms" ]
-keywords = [
-    "cryptography",
-    "proxy-re-encryption",
-    "PRE",
-    "ECC",
-    "transform-encryption",
-]
+categories = ["cryptography", "algorithms"]
+keywords = ["cryptography", "proxy-re-encryption", "PRE", "ECC", "transform-encryption"]
 description = "A pure-Rust implementation of Transform Encryption, a Proxy Re-encryption scheme"
 edition = "2021"
 rust-version = "1.56.0"
 
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies]
-libc = { version = "0.2" }
+libc = {version = "0.2"}
 
 [target.'cfg(all(windows, not(target_arch = "wasm32")))'.dependencies]
-winapi = { version = "0.3", features = [ "memoryapi", "sysinfoapi" ] }
+winapi = {version = "0.3", features = ["memoryapi", "sysinfoapi"]}
 
 [dependencies]
 cfg-if = "1"
 clear_on_drop = "0.2"
 derivative = "2.1"
 # Disable all features for ed25519 and enable the proper ones down in the [features] section below
-ed25519-dalek = { version = "=0.1.0", default-features = false, features = [
-    "std",
-], package = "ed25519-dalek-fiat" }
+ed25519-dalek = {version = "=0.1.0", default-features = false, features = ["std"], package = "ed25519-dalek-fiat"}
 # Explicit dependency so we can pass the wasm-bindgen flag to it
-getrandom = { version = "0.2", optional = true }
+getrandom = {version = "0.2", optional = true}
 gridiron = "0.10"
 hex = "0.4"
 lazy_static = "1.4"
@@ -63,10 +55,10 @@ debug = false
 lto = true
 
 [features]
-default = [ "u64_backend" ]
-u64_backend = [ "ed25519-dalek/u64_backend" ]
-u32_backend = [ "ed25519-dalek/u32_backend" ]
-wasm = [ "u32_backend", "clear_on_drop/no_cc", "getrandom/js" ]
+default = ["u64_backend"]
+u64_backend = ["ed25519-dalek/u64_backend"]
+u32_backend = ["ed25519-dalek/u32_backend"]
+wasm = ["u32_backend", "clear_on_drop/no_cc", "getrandom/js"]
 #Can be used to disable the automatic mlock detection for architectures.
 disable_memlock = []
 

--- a/src/internal/ed25519.rs
+++ b/src/internal/ed25519.rs
@@ -164,11 +164,11 @@ impl Ed25519Signing for Ed25519 {
         signature: &Ed25519Signature,
         public_key: &PublicSigningKey,
     ) -> bool {
-        use ed25519_dalek::ed25519::signature::Signature;
         use ed25519_dalek::Verifier;
+
         PublicKey::from_bytes(&public_key.bytes[..])
             .and_then(|pk| {
-                ed25519_dalek::Signature::from_bytes(&signature.bytes[..])
+                TryFrom::try_from(&signature.bytes[..])
                     .and_then(|sig| pk.verify(&t.to_bytes()[..], &sig))
             })
             .map(|_| true)


### PR DESCRIPTION
Removes an unnecessary `use` statement and instead uses the `TryFrom` implementation to create a signature from bytes. The use statement was reintroduced to fix compilation errors for some combinations of dependencies introduced in v0.13.0, but  the `TryFrom` approach has the same effect with no compiler warning.