### PR TITLE
Investigate Apple M1/arm64 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,8 @@ jobs:
             target: aarch64-apple-ios
           - os: macos-10.15
             target: x86_64-apple-darwin # 64-bit OSX
+          - os: macos-11
+            target: aarch64-apple-darwin # 64-bit M1 OSX
           - os: windows-2019
             target: x86_64-pc-windows-msvc
     steps:


### PR DESCRIPTION
Checking out how possible IronCoreLabs/ironnode#70 might be, given our personal lack of M1 chips to try it out on.

Looks like cross compilation on a macosx-11 machine will work, targeting `aarch64-apple-darwin`.