### PR TITLE
Move off macos-12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,11 @@ jobs:
         - os: ubuntu-22.04
           target: wasm32-unknown-unknown
           features: --features wasm --no-default-features
-        - os: macos-12
+        - os: macos-13
           target: aarch64-apple-ios
-        - os: macos-12
+        - os: macos-13
           target: x86_64-apple-darwin # 64-bit OSX
-        - os: macos-12
+        - os: macos-14
           target: aarch64-apple-darwin # 64-bit M1 OSX
         - os: windows-2019
           target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Can't move everything to macos-14, because GitHub only has ARM-based runners for macos-14.