### PR TITLE
Enable `fast` feature of ed25519-dalek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.14.1 (2024-12-05)
+
+- [[#190](https://github.com/IronCoreLabs/recrypt-rs/pull/190)]
+  - Fix performance regression with generating ed25519 keypairs introduced in 0.14.0.
+
 ## 0.14.0 (2024-12-03)
 
 - [[#184](https://github.com/IronCoreLabs/recrypt-rs/pull/188)]
@@ -15,9 +20,11 @@
 ## 0.13.1 (2021-11-29)
 
 ### Public API changes
+
 None
 
 ### Notable internal changes
+
 [[#163]](https://github.com/IronCoreLabs/recrypt-rs/pull/163) Fix compilation error for certain combinations of transitive dependencies related to ed25519-dalek-fiat
 
 ## 0.13.0 (yanked)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recrypt"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,25 +7,34 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/IronCoreLabs/recrypt-rs"
 documentation = "https://docs.rs/recrypt"
 categories = ["cryptography", "algorithms"]
-keywords = ["cryptography", "proxy-re-encryption", "PRE", "ECC", "transform-encryption"]
+keywords = [
+    "cryptography",
+    "proxy-re-encryption",
+    "PRE",
+    "ECC",
+    "transform-encryption",
+]
 description = "A pure-Rust implementation of Transform Encryption, a Proxy Re-encryption scheme"
 edition = "2021"
 rust-version = "1.70.0"
 
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies]
-libc = {version = "0.2"}
+libc = { version = "0.2" }
 
 [target.'cfg(all(windows, not(target_arch = "wasm32")))'.dependencies]
-winapi = {version = "0.3", features = ["memoryapi", "sysinfoapi"]}
+winapi = { version = "0.3", features = ["memoryapi", "sysinfoapi"] }
 
 [dependencies]
 cfg-if = "1"
 clear_on_drop = "0.2"
 derivative = "2.1"
-# Disable all features for ed25519 and enable the proper ones down in the [features] section below
-ed25519-dalek = {version = "2.1.1", default-features = false, features = ["std", "rand_core"]}
+ed25519-dalek = { version = "2.1.1", default-features = false, features = [
+    "std",
+    "rand_core",
+    "fast",
+] }
 # Explicit dependency so we can pass the wasm-bindgen flag to it
-getrandom = {version = "0.2", optional = true}
+getrandom = { version = "0.2", optional = true }
 gridiron = "0.10"
 hex = "0.4"
 lazy_static = "1.4"

--- a/benches/api_benchmark.rs
+++ b/benches/api_benchmark.rs
@@ -7,10 +7,10 @@ use recrypt::api::CryptoOps;
 use recrypt::api::Ed25519Ops;
 use recrypt::api::KeyGenOps;
 use recrypt::api::Recrypt;
-use recrypt::api_480::CryptoOps as CryptoOps480;
-use recrypt::api_480::Ed25519Ops as Ed25519Ops480;
-use recrypt::api_480::KeyGenOps as KeyGenOps480;
-use recrypt::api_480::Recrypt480;
+// use recrypt::api_480::CryptoOps as CryptoOps480;
+// use recrypt::api_480::Ed25519Ops as Ed25519Ops480;
+// use recrypt::api_480::KeyGenOps as KeyGenOps480;
+// use recrypt::api_480::Recrypt480;
 use std::cell::RefCell;
 
 macro_rules! recrypt_bench {
@@ -213,7 +213,7 @@ macro_rules! recrypt_bench {
     };
 }
 
-recrypt_bench! {api = Recrypt480; suite_desc = criterion_benchmark_fp480; bits = "480"}
+// recrypt_bench! {api = Recrypt480; suite_desc = criterion_benchmark_fp480; bits = "480"}
 recrypt_bench! {api = Recrypt; suite_desc = criterion_benchmark_fp256; bits = "256"}
 
 criterion_group! {

--- a/benches/api_benchmark.rs
+++ b/benches/api_benchmark.rs
@@ -7,14 +7,15 @@ use recrypt::api::CryptoOps;
 use recrypt::api::Ed25519Ops;
 use recrypt::api::KeyGenOps;
 use recrypt::api::Recrypt;
-// use recrypt::api_480::CryptoOps as CryptoOps480;
-// use recrypt::api_480::Ed25519Ops as Ed25519Ops480;
-// use recrypt::api_480::KeyGenOps as KeyGenOps480;
-// use recrypt::api_480::Recrypt480;
+use recrypt::api_480::CryptoOps as CryptoOps480;
+use recrypt::api_480::Ed25519Ops as Ed25519Ops480;
+use recrypt::api_480::KeyGenOps as KeyGenOps480;
+use recrypt::api_480::Recrypt480;
 use std::cell::RefCell;
 
 macro_rules! recrypt_bench {
     (api = $api:ident; suite_desc = $suite_desc:ident; bits = $bits:tt) => {
+        #[allow(dead_code)]
         fn $suite_desc(c: &mut Criterion) {
             c.bench_function(concat!($bits, "-bit generate key pair"), |b| {
                 let api = $api::new();
@@ -213,7 +214,8 @@ macro_rules! recrypt_bench {
     };
 }
 
-// recrypt_bench! {api = Recrypt480; suite_desc = criterion_benchmark_fp480; bits = "480"}
+// Note: this benchmark is currently unused. Uncomment `criterion_benchmark_fp480` below to run it as well.
+recrypt_bench! {api = Recrypt480; suite_desc = criterion_benchmark_fp480; bits = "480"}
 recrypt_bench! {api = Recrypt; suite_desc = criterion_benchmark_fp256; bits = "256"}
 
 criterion_group! {


### PR DESCRIPTION
This fixes a performance regression introduced in 0.14.0 around generating ed25519 keypairs. It will now utilize precomputer basepoint multiplication tables. 